### PR TITLE
Update README workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,30 +60,15 @@ print(categorias)  # {'respuestas': ['Var1 es BAJO, Var2 es BAJO.']}
 
 Permite generalizar condiciones de variables numéricas en categorías de nivel.
 
-### `Models`
 
-```python
-from InsideForest.models import Models
-
-m = Models()
-fp_rows, resto = m.get_knn_rows(df_train, 'target', criterio_fp=True)
-param_grid = {'n_estimators': [50, 100], 'max_depth': [None, 5]}
-cv_model = m.get_cvRF(X_train, y_train, param_grid)
-```
-
-Proporciona métodos para obtener observaciones críticas con KNN y ajustar un bosque aleatorio con validación cruzada.
-
-### `Labels`
-
-```python
-from InsideForest.labels import Labels
-
-lb = Labels()
-etiquetas = lb.get_labels(df_reres, df, 'target', etq_max=5)
-```
-
-Genera etiquetas descriptivas de las ramas y clusters obtenidos del modelo.
-
+## Flujo de trabajo básico
+El orden típico para aplicar InsideForest es:
+1. Entrenar un modelo de bosques de decisión o `RandomForest`.
+2. Usar `Trees.get_branches` para extraer las ramas de cada árbol.
+3. Aplicar `Regions.prio_ranges` para priorizar las zonas de interés.
+4. Asociar cada observación con `Regions.labels`.
+5. Opcionalmente, interpretar con `generate_descriptions` y `categorize_conditions`.
+6. Finalmente, emplear utilidades como `Models` y `Labels` si se requieren análisis adicionales.
 ## Caso de uso (Iris)
 A continuación se muestra un resumen del flujo utilizado en el [notebook de ejemplo](https://colab.research.google.com/drive/11VGeB0V6PLMlQ8Uhba91fJ4UN1Bfbs90?usp=sharing).
 
@@ -143,6 +128,30 @@ for df_r in df_reres[:3]:
 ![Plot 2](./data/plot_2.png)
 
 Las zonas azules representan las ramas más relevantes del bosque y permiten interpretar dónde se concentra la variable objetivo.
+
+### `Models`
+
+```python
+from InsideForest.models import Models
+
+m = Models()
+fp_rows, resto = m.get_knn_rows(df_train, 'target', criterio_fp=True)
+param_grid = {'n_estimators': [50, 100], 'max_depth': [None, 5]}
+cv_model = m.get_cvRF(X_train, y_train, param_grid)
+```
+
+Proporciona métodos para obtener observaciones críticas con KNN y ajustar un bosque aleatorio con validación cruzada.
+
+### `Labels`
+
+```python
+from InsideForest.labels import Labels
+
+lb = Labels()
+etiquetas = lb.get_labels(df_reres, df, 'target', etq_max=5)
+```
+
+Genera etiquetas descriptivas de las ramas y clusters obtenidos del modelo.
 
 ## Licencia
 


### PR DESCRIPTION
## Summary
- document basic workflow ordering for using InsideForest
- move `Models` and `Labels` sections to the end of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879d7e107ec832cb90af2483e047f79