### PR TITLE
Switch Spanish equality statements to mathematical notation

### DIFF
--- a/InsideForest/models.py
+++ b/InsideForest/models.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 class Models:
   def get_knn_rows(self, df, target_col, criterio_fp=True, min_obs = 5):
     if target_col not in df.columns:
-      raise KeyError(f"La columna objetivo '{target_col}' no existe en el DataFrame")
+        raise KeyError(f"Target column '{target_col}' does not exist in the DataFrame")
 
     X = df.drop(columns=[target_col]).values
     y = df.loc[:, target_col].values
@@ -21,7 +21,7 @@ class Models:
         y_pred = knn.predict(X)
         cm = confusion_matrix(y, y_pred)
       except Exception as exc:
-        logger.exception("Error al entrenar KNN: %s", exc)
+        logger.exception("Error training KNN: %s", exc)
         break
       tn, fp, fn, tp = cm.ravel()
       if criterio_fp:

--- a/InsideForest/regions.py
+++ b/InsideForest/regions.py
@@ -893,7 +893,7 @@ class Regions:
       """
       # Asegurar que la columna de clusters contiene listas o sets
       if not df[columna_clusters].apply(lambda x: isinstance(x, (list, set))).all():
-          raise ValueError(f"La columna '{columna_clusters}' debe contener listas o sets de clusters.")
+          raise ValueError(f"Column '{columna_clusters}' must contain lists or sets of clusters.")
       
       # Inicializar el binarizador
       mlb = MultiLabelBinarizer()
@@ -943,7 +943,7 @@ class Regions:
       # Validar que las columnas existen
       for col in cluster_columns:
           if col not in df.columns:
-              raise ValueError(f"La columna '{col}' no existe en el DataFrame.")
+              raise ValueError(f"Column '{col}' does not exist in the DataFrame.")
       
       # Preparar los datos para clustering
       X = df[cluster_columns].values
@@ -1077,7 +1077,7 @@ class Regions:
               cluster_number = col.split('_')[1].split('.')[0]
               cluster_mapping[col] = int(cluster_number)
           except (IndexError, ValueError):
-              raise ValueError(f"El formato de la columna '{col}' no es válido. Esperado 'cluster_<número>.0'.")
+              raise ValueError(f"The format of column '{col}' is invalid. Expected 'cluster_<number>.0'.")
       
       # Utilizar una lista por comprensión para obtener los clusters activos por fila
       df[new_column] = [
@@ -1103,7 +1103,7 @@ class Regions:
       - pd.DataFrame: DataFrame con la nueva columna de llaves.
       """
       if list_column not in df.columns:
-          raise KeyError(f"La columna '{list_column}' no existe en el DataFrame")
+          raise KeyError(f"Column '{list_column}' does not exist in the DataFrame")
 
       if sorted:
           df[new_key_column] = df[list_column].apply(lambda x: delimiter.join(map(str, sorted(x))))
@@ -1115,7 +1115,7 @@ class Regions:
     """Identifica los clusters más representativos de un DataFrame."""
 
     if 'clusters_list' not in df_clusterizado.columns:
-      raise KeyError("El DataFrame debe contener la columna 'clusters_list'")
+        raise KeyError("DataFrame must contain the 'clusters_list' column")
 
     try:
       df_clusterizado_diff = df_clusterizado[['clusters_list']].drop_duplicates()
@@ -1196,7 +1196,7 @@ class Regions:
             how='left'
         )
     except Exception as exc:
-        logger.exception("Error al combinar clusters: %s", exc)
+        logger.exception("Error combining clusters: %s", exc)
         return df_clusterizado
 
     return df_clusterizado_add.drop(columns='clusters_key')
@@ -1533,7 +1533,7 @@ class Regions:
           correlaciones_ordenadas = correlaciones.reindex(correlaciones.abs().sort_values(ascending=True).index)
           top_n = correlaciones_ordenadas.head(n)
       else:
-          raise ValueError("El parámetro 'direccion' debe ser 'arriba', 'abajo', 'ambos' o 'bottom'.")
+          raise ValueError("Parameter 'direccion' must be 'arriba', 'abajo', 'ambos' or 'bottom'.")
       
       return top_n.sort_values(ascending=False)
 

--- a/InsideForest/trees.py
+++ b/InsideForest/trees.py
@@ -416,7 +416,7 @@ class Trees:
     :return: Lista de DataFrames con los rectángulos separados por dimensión
     """
     if var_obj not in df.columns:
-       raise KeyError(f"La columna objetivo '{var_obj}' no existe en el DataFrame")
+       raise KeyError(f"Target column '{var_obj}' does not exist in the DataFrame")
 
     # Separamos X e ignoramos la columna objetivo
     df_copy = df.copy()

--- a/tests/test_descrip.py
+++ b/tests/test_descrip.py
@@ -12,14 +12,14 @@ def test_categorize_conditions_basic():
     df = pd.DataFrame({'Var1': range(100), 'Var2': range(100)})
     conds = ['0 <= Var1 <= 10 and 0 <= Var2 <= 10']
     result = categorize_conditions(conds, df, n_groups=2)
-    assert result == {'respuestas': ['Var1 es Percentile 50, Var2 es Percentile 50.']}
+    assert result == {'responses': ['Var1 = Percentile 50, Var2 = Percentile 50.']}
 
 
 def test_categorize_conditions_three_groups():
     df = pd.DataFrame({'Var1': range(100), 'Var2': range(100)})
     conds = ['70 <= Var1 <= 90 and 10 <= Var2 <= 40']
     result = categorize_conditions(conds, df, n_groups=3)
-    assert result == {'respuestas': ['Var1 es Percentile 100, Var2 es Percentile 33.33.']}
+    assert result == {'responses': ['Var1 = Percentile 100, Var2 = Percentile 33.33.']}
 
 
 def test_categorize_conditions_invalid_inputs():
@@ -34,14 +34,14 @@ def test_categorize_conditions_generalized_boolean():
     df = pd.DataFrame({'Var1': [True, False] * 50, 'Var2': range(100)})
     conds = ['Var1 == True and 10 <= Var2 <= 30']
     result = categorize_conditions_generalized(conds, df, n_groups=2)
-    assert result == {'respuestas': ['Var1 es TRUE, Var2 es Percentile 50.']}
+    assert result == {'responses': ['Var1 = TRUE, Var2 = Percentile 50.']}
 
 
 def test_categorize_conditions_generalized_boolean_false():
     df = pd.DataFrame({'Var1': [True, False] * 50})
     conds = ['Var1 == False']
     result = categorize_conditions_generalized(conds, df, n_groups=2)
-    assert result == {'respuestas': ['Var1 es FALSE.']}
+    assert result == {'responses': ['Var1 = FALSE.']}
 
 
 def test_build_conditions_table_basic():
@@ -69,4 +69,4 @@ def test_categorize_conditions_equal_percentiles():
     df = pd.DataFrame({'Var1': [5] * 100})
     conds = ['5 <= Var1 <= 5']
     result = categorize_conditions(conds, df, n_groups=3)
-    assert result == {'respuestas': ['Var1 es Percentile 100.']}
+    assert result == {'responses': ['Var1 = Percentile 100.']}


### PR DESCRIPTION
## Summary
- update `categorize_conditions` outputs to use `=` instead of `es`
- adjust regex and parsing to accept the new format
- translate remaining Spanish error strings and dictionary keys to English

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688be2655c24832c977d1969cd70681b