### PR TITLE
Simplify plot_experiments interface

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -128,6 +128,34 @@ labels_out = lb.get_labels(rangos_priorizados, df, 'target', max_labels=5)
 
 Genera etiquetas descriptivas para las ramas y clusters obtenidos del modelo.
 
+### `plot_experiments`
+
+```python
+from InsideForest.regions import Regions
+from sklearn.datasets import load_iris
+import pandas as pd
+
+# Fila de ejemplo de una tabla de experimentos
+experimento = {
+    "intersection": "[5.45 <= petal_length <= 8.9]",
+    "only_cluster_a": "[-0.9 <= sepal_width <= 1.55, 4.75 <= sepal_length <= 6.0]",
+    "only_cluster_b": "[1.0 <= petal_width <= 3.0, 1.7 <= sepal_width <= 3.3]",
+    "variables_a": "['sepal_length', 'sepal_width']",
+    "variables_b": "['petal_width', 'sepal_length', 'sepal_width']"
+}
+
+iris = load_iris()
+df = pd.DataFrame(
+    iris.data,
+    columns=[c.replace(' (cm)', '').replace(' ', '_') for c in iris.feature_names]
+)
+
+regions = Regions()
+regions.plot_experiments(df, experimento, interactive=False)
+```
+
+Compara los clusters A y B usando las reglas de una fila de la tabla de experimentos.
+
 ## Licencia
 
 Este proyecto se distribuye bajo la licencia MIT. Consulta [LICENSE](LICENSE) para más detalles.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,34 @@ labels_out = lb.get_labels(priority_ranges, df, 'target', max_labels=5)
 
 Generates descriptive labels for the branches and clusters obtained from the model.
 
+### `plot_experiments`
+
+```python
+from InsideForest.regions import Regions
+from sklearn.datasets import load_iris
+import pandas as pd
+
+# Example row from an experiments table
+experiment = {
+    "intersection": "[5.45 <= petal_length <= 8.9]",
+    "only_cluster_a": "[-0.9 <= sepal_width <= 1.55, 4.75 <= sepal_length <= 6.0]",
+    "only_cluster_b": "[1.0 <= petal_width <= 3.0, 1.7 <= sepal_width <= 3.3]",
+    "variables_a": "['sepal_length', 'sepal_width']",
+    "variables_b": "['petal_width', 'sepal_length', 'sepal_width']"
+}
+
+iris = load_iris()
+df = pd.DataFrame(
+    iris.data,
+    columns=[c.replace(' (cm)', '').replace(' ', '_') for c in iris.feature_names]
+)
+
+regions = Regions()
+regions.plot_experiments(df, experiment, interactive=False)
+```
+
+Compares clusters A and B using the rules provided by a row from the experiments table.
+
 ## License
 
 This project is distributed under the MIT license. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- Accept experiment table rows directly in `Regions.plot_experiments`
- Parse string fields to lists and plot accordingly
- Document `plot_experiments` usage in both English and Spanish README files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689520ebaac8832cb1e0e7feea05412c