### PR TITLE
Add tests for InsideForest fit and predict methods

### DIFF
--- a/tests/test_inside_forest_fit_predict.py
+++ b/tests/test_inside_forest_fit_predict.py
@@ -1,0 +1,26 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pandas as pd
+import numpy as np
+import pytest
+
+from InsideForest.inside_forest import InsideForest
+
+
+def test_inside_forest_fit_predict_runs():
+    X = pd.DataFrame({'feat1': [0, 1, 2, 3], 'feat2': [3, 2, 1, 0]})
+    y = [0, 1, 0, 1]
+    model = InsideForest(rf_params={'n_estimators': 5, 'random_state': 0})
+    fitted = model.fit(X, y)
+    assert fitted is model
+    preds = model.predict(X)
+    assert preds.shape == (4,)
+    assert np.array_equal(preds, model.labels_)
+
+
+def test_predict_before_fit_raises():
+    model = InsideForest()
+    X = pd.DataFrame({'feat1': [0], 'feat2': [0]})
+    with pytest.raises(RuntimeError):
+        model.predict(X)


### PR DESCRIPTION
## Summary
- add coverage for InsideForest.fit/predict ensuring labels are assigned
- assert predict raises when called before fitting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68959a6c02b4832c961e1b35c0e56cdf