### PR TITLE
Allow DataFrame input in fit and expose frontiers

### DIFF
--- a/InsideForest/inside_forest.py
+++ b/InsideForest/inside_forest.py
@@ -3,6 +3,7 @@ from sklearn.ensemble import RandomForestClassifier
 
 from .trees import Trees
 from .regions import Regions
+from .descrip import get_frontiers
 
 
 class InsideForest:
@@ -18,12 +19,36 @@ class InsideForest:
     var_obj : str, default "target"
         Name of the column created for the target variable when building the
         internal DataFrame used for rule extraction.
+    n_clusters : int or None, optional
+        Desired number of clusters passed to :meth:`Regions.labels`.
+    include_summary_cluster : bool, default False
+        Whether to keep summary columns in the output of
+        :meth:`Regions.labels`.
+    balanced : bool, default False
+        Use balanced assignment of cluster labels instead of probability based
+        assignment in :meth:`Regions.labels`.
+    divide : int, default 5
+        Value forwarded to :func:`get_frontiers` when computing cluster
+        frontiers.
     """
 
-    def __init__(self, rf_params=None, tree_params=None, var_obj="target"):
+    def __init__(
+        self,
+        rf_params=None,
+        tree_params=None,
+        var_obj="target",
+        n_clusters=None,
+        include_summary_cluster=False,
+        balanced=False,
+        divide=5,
+    ):
         self.rf_params = rf_params or {}
         self.tree_params = tree_params or {}
         self.var_obj = var_obj
+        self.n_clusters = n_clusters
+        self.include_summary_cluster = include_summary_cluster
+        self.balanced = balanced
+        self.divide = divide
 
         # Instantiate internal helpers
         self.rf = RandomForestClassifier(**self.rf_params)
@@ -35,46 +60,85 @@ class InsideForest:
         self.feature_names_ = None
         self.df_clusters_descript_ = None
         self.df_reres_ = None
+        self.df_datos_explain_ = None
+        self.frontiers_ = None
 
-    def fit(self, X, y):
+    def fit(self, X, y=None):
         """Fit the internal RandomForest and compute cluster labels.
 
         Parameters
         ----------
         X : array-like or pandas.DataFrame
-            Feature matrix.
-        y : array-like
-            Target vector.
+            Feature matrix or DataFrame containing the target column.
+        y : array-like, optional
+            Target vector. If not provided and ``X`` is a DataFrame containing
+            ``var_obj``, that column will be used as the target.
+
+        Raises
+        ------
+        ValueError
+            If ``y`` is ``None`` and ``X`` does not contain ``var_obj`` as a
+            column.
         """
 
-        # Ensure DataFrame with meaningful column names
-        if isinstance(X, pd.DataFrame):
-            X_df = X.copy()
+        if y is None:
+            if isinstance(X, pd.DataFrame):
+                if self.var_obj in X.columns:
+                    y = X[self.var_obj]
+                    X_df = X.drop(columns=[self.var_obj])
+                else:
+                    raise ValueError(
+                        f"Target column '{self.var_obj}' not found in DataFrame. "
+                        "Provide the target column name via 'var_obj' or pass 'y' explicitly."
+                    )
+            else:
+                raise ValueError(
+                    "When 'y' is None, 'X' must be a DataFrame containing the target column."
+                )
         else:
-            X_df = pd.DataFrame(X)
+            if isinstance(X, pd.DataFrame):
+                X_df = X.copy()
+            else:
+                X_df = pd.DataFrame(data=X)
 
         # Replace spaces with underscores to keep compatibility with Trees
         X_df.columns = [str(c).replace(" ", "_") for c in X_df.columns]
         self.feature_names_ = list(X_df.columns)
 
         # Train RandomForest
-        self.rf.fit(X_df, y)
+        self.rf.fit(X=X_df, y=y)
 
         # Build DataFrame including target for region extraction
         df = X_df.copy()
         df[self.var_obj] = y
 
         # Extract rules and compute labels using existing utilities
-        separacion_dim = self.trees.get_branches(df, self.var_obj, self.rf)
-        df_reres = self.regions.prio_ranges(separacion_dim, df)
+        separacion_dim = self.trees.get_branches(
+            df=df, var_obj=self.var_obj, regr=self.rf
+        )
+        df_reres = self.regions.prio_ranges(
+            separacion_dim=separacion_dim, df=df
+        )
         df_datos_clusterizados, df_clusters_descripcion = self.regions.labels(
-            df, df_reres, False
+            df=df,
+            df_reres=df_reres,
+            n_clusters=self.n_clusters,
+            include_summary_cluster=self.include_summary_cluster,
+            balanced=self.balanced,
         )
 
-        df_datos_clusterizados["cluster"] = df_datos_clusterizados["cluster"].fillna(-1)
+        df_datos_clusterizados["cluster"] = df_datos_clusterizados["cluster"].fillna(
+            value=-1
+        )
         self.labels_ = df_datos_clusterizados["cluster"].to_numpy()
         self.df_clusters_descript_ = df_clusters_descripcion
         self.df_reres_ = df_reres
+
+        df_datos_explain, frontiers = get_frontiers(
+            df_datos_descript=df_clusters_descripcion, df=df, divide=self.divide
+        )
+        self.df_datos_explain_ = df_datos_explain
+        self.frontiers_ = frontiers
 
         return self
 
@@ -103,8 +167,14 @@ class InsideForest:
             # Reorder/Subset columns to match training features
             X_df = X_df[self.feature_names_]
         else:
-            X_df = pd.DataFrame(X, columns=self.feature_names_)
+            X_df = pd.DataFrame(data=X, columns=self.feature_names_)
 
-        df_clusterizado, _ = self.regions.labels(X_df, self.df_reres_, False)
-        df_clusterizado["cluster"] = df_clusterizado["cluster"].fillna(-1)
+        df_clusterizado, _ = self.regions.labels(
+            df=X_df,
+            df_reres=self.df_reres_,
+            n_clusters=self.n_clusters,
+            include_summary_cluster=False,
+            balanced=self.balanced,
+        )
+        df_clusterizado["cluster"] = df_clusterizado["cluster"].fillna(value=-1)
         return df_clusterizado["cluster"].to_numpy()

--- a/tests/test_inside_forest_fit_predict.py
+++ b/tests/test_inside_forest_fit_predict.py
@@ -9,18 +9,60 @@ from InsideForest.inside_forest import InsideForest
 
 
 def test_inside_forest_fit_predict_runs():
-    X = pd.DataFrame({'feat1': [0, 1, 2, 3], 'feat2': [3, 2, 1, 0]})
+    X = pd.DataFrame(data={'feat1': [0, 1, 2, 3], 'feat2': [3, 2, 1, 0]})
     y = [0, 1, 0, 1]
     model = InsideForest(rf_params={'n_estimators': 5, 'random_state': 0})
-    fitted = model.fit(X, y)
+    fitted = model.fit(X=X, y=y)
     assert fitted is model
-    preds = model.predict(X)
+    preds = model.predict(X=X)
     assert preds.shape == (4,)
     assert np.array_equal(preds, model.labels_)
 
 
 def test_predict_before_fit_raises():
     model = InsideForest()
-    X = pd.DataFrame({'feat1': [0], 'feat2': [0]})
+    X = pd.DataFrame(data={'feat1': [0], 'feat2': [0]})
     with pytest.raises(RuntimeError):
-        model.predict(X)
+        model.predict(X=X)
+
+
+def test_fit_accepts_df_with_target_column():
+    df = pd.DataFrame(data={
+        'feat1': [0, 1, 2, 3],
+        'feat2': [3, 2, 1, 0],
+        'target': [0, 1, 0, 1]
+    })
+    model = InsideForest(rf_params={'n_estimators': 5, 'random_state': 0})
+    fitted = model.fit(X=df)
+    assert fitted is model
+    assert model.labels_.shape[0] == len(df)
+
+
+def test_fit_df_missing_target_raises():
+    df = pd.DataFrame(data={'feat1': [0, 1], 'feat2': [1, 0]})
+    model = InsideForest()
+    with pytest.raises(ValueError):
+        model.fit(X=df)
+
+
+def test_custom_label_and_frontier_params():
+    df = pd.DataFrame(
+        data={
+            'feat1': [0, 1, 2, 3],
+            'feat2': [3, 2, 1, 0],
+            'target': [0, 1, 0, 1],
+        }
+    )
+    model = InsideForest(
+        rf_params={'n_estimators': 5, 'random_state': 0},
+        n_clusters=2,
+        include_summary_cluster=True,
+        balanced=True,
+        divide=3,
+    )
+    model.fit(X=df)
+    assert model.n_clusters == 2
+    assert model.include_summary_cluster is True
+    assert model.balanced is True
+    assert model.divide == 3
+    assert model.labels_.shape[0] == len(df)


### PR DESCRIPTION
## Summary
- Let `InsideForest` accept `n_clusters`, `include_summary_cluster`, `balanced` and `divide` at instantiation
- Use keyword arguments when invoking internal helpers and save frontier outputs on the model
- Add tests covering custom label/frontier parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896a77e61dc832cbca486cbd4753263