### PR TITLE
Allow custom RandomForest in fit

### DIFF
--- a/InsideForest/inside_forest.py
+++ b/InsideForest/inside_forest.py
@@ -63,7 +63,7 @@ class InsideForest:
         self.df_datos_explain_ = None
         self.frontiers_ = None
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, rf=None):
         """Fit the internal RandomForest and compute cluster labels.
 
         Parameters
@@ -73,6 +73,9 @@ class InsideForest:
         y : array-like, optional
             Target vector. If not provided and ``X`` is a DataFrame containing
             ``var_obj``, that column will be used as the target.
+        rf : RandomForestClassifier, optional
+            Custom ``RandomForestClassifier`` instance to use during fitting.
+            If ``None``, the classifier created during initialization is used.
 
         Raises
         ------
@@ -104,6 +107,10 @@ class InsideForest:
         # Replace spaces with underscores to keep compatibility with Trees
         X_df.columns = [str(c).replace(" ", "_") for c in X_df.columns]
         self.feature_names_ = list(X_df.columns)
+
+        # Allow passing a custom RandomForestClassifier
+        if rf is not None:
+            self.rf = rf
 
         # Train RandomForest
         self.rf.fit(X=X_df, y=y)

--- a/InsideForest/inside_forest.py
+++ b/InsideForest/inside_forest.py
@@ -1,5 +1,7 @@
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
+from sklearn.exceptions import NotFittedError
+from sklearn.utils.validation import check_is_fitted
 
 from .trees import Trees
 from .regions import Regions
@@ -76,6 +78,8 @@ class InsideForest:
         rf : RandomForestClassifier, optional
             Custom ``RandomForestClassifier`` instance to use during fitting.
             If ``None``, the classifier created during initialization is used.
+            If the provided estimator is already trained, it will be used as
+            is without additional fitting.
 
         Raises
         ------
@@ -112,8 +116,11 @@ class InsideForest:
         if rf is not None:
             self.rf = rf
 
-        # Train RandomForest
-        self.rf.fit(X=X_df, y=y)
+        # Train RandomForest only if it has not been fitted already
+        try:
+            check_is_fitted(self.rf)
+        except NotFittedError:
+            self.rf.fit(X=X_df, y=y)
 
         # Build DataFrame including target for region extraction
         df = X_df.copy()

--- a/README.es.md
+++ b/README.es.md
@@ -48,6 +48,8 @@ El orden típico para aplicar InsideForest es:
 Para un flujo simplificado puedes utilizar la clase `InsideForest`, que combina
 el entrenamiento del bosque aleatorio y la asignación de regiones:
 
+Nota: InsideForest está pensado para ejecutarse sobre un subconjunto de los datos, por ejemplo usar el 35% de las observaciones y reservar el 65% restante para otros fines.
+
 ```python
 from sklearn.datasets import load_iris
 from InsideForest import InsideForest

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The typical order for applying InsideForest is:
 For a simplified workflow you can use the `InsideForest` class, which combines
 the random forest training and region labeling steps:
 
+Note: InsideForest is typically run on a subset of the data, for example using 35% of the observations and reserving the remaining 65% for other purposes.
+
 ```python
 from sklearn.datasets import load_iris
 from InsideForest import InsideForest

--- a/tests/test_inside_forest_fit_predict.py
+++ b/tests/test_inside_forest_fit_predict.py
@@ -4,6 +4,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import pandas as pd
 import numpy as np
 import pytest
+from sklearn.ensemble import RandomForestClassifier
 
 from InsideForest.inside_forest import InsideForest
 
@@ -66,3 +67,16 @@ def test_custom_label_and_frontier_params():
     assert model.balanced is True
     assert model.divide == 3
     assert model.labels_.shape[0] == len(df)
+
+
+def test_fit_accepts_custom_rf_instance():
+    X = pd.DataFrame(data={'feat1': [0, 1, 2, 3], 'feat2': [3, 2, 1, 0]})
+    y = [0, 1, 0, 1]
+    rf = RandomForestClassifier(n_estimators=5, random_state=0)
+    model = InsideForest()
+    fitted = model.fit(X=X, y=y, rf=rf)
+    assert fitted is model
+    assert model.rf is rf
+    preds = model.predict(X=X)
+    assert preds.shape == (4,)
+    assert np.array_equal(preds, model.labels_)


### PR DESCRIPTION
## Summary
- allow passing a custom `RandomForestClassifier` to `InsideForest.fit`
- test that a provided classifier is used during fitting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896b59cac84832c99517415d910a33b