### PR TITLE
Add InsideForestRegressor wrapper

### DIFF
--- a/InsideForest/__init__.py
+++ b/InsideForest/__init__.py
@@ -2,7 +2,7 @@ from .labels import Labels
 from .regions import Regions
 from .trees import Trees
 from .models import Models
-from .inside_forest import InsideForest
+from .inside_forest import InsideForestClassifier, InsideForestRegressor
 from .metadata import (
     MetaExtractor,
     Profile,
@@ -12,3 +12,6 @@ from .metadata import (
     experiments_from_df2,
     run_experiments,
 )
+
+# Backward compatibility
+InsideForest = InsideForestClassifier

--- a/InsideForest/trees.py
+++ b/InsideForest/trees.py
@@ -155,7 +155,10 @@ class Trees:
 
         paths.append([x for x in path_ if x != ''])
 
-      valores = [float(path[1].split(': ')[1].replace(']', '')) for path in paths]
+      valores = [
+        float(path[1].split(': ')[1].replace('[', '').replace(']', ''))
+        for path in paths
+      ]
       percent_ = np.percentile(valores, 90)
       estructuras_maximizadoras = [[pa[0], val] for pa, val in zip(paths, valores) if val >= percent_]
 

--- a/README.es.md
+++ b/README.es.md
@@ -44,16 +44,17 @@ El orden típico para aplicar InsideForest es:
 5. Opcionalmente interpretar resultados con `generate_descriptions` y `categorize_conditions`.
 6. Finalmente, usar utilidades como `Models` y `Labels` para un análisis adicional.
 
-## Ejemplo con InsideForest
-Para un flujo simplificado puedes utilizar la clase `InsideForest`, que combina
-el entrenamiento del bosque aleatorio y la asignación de regiones:
+## InsideForestClassifier e InsideForestRegressor
+Para un flujo simplificado puedes utilizar las clases `InsideForestClassifier` o
+`InsideForestRegressor`, que combinan el entrenamiento del bosque aleatorio y la
+asignación de regiones:
 
 Nota: InsideForest está pensado para ejecutarse sobre un subconjunto de los datos, por ejemplo usar el 35% de las observaciones y reservar el 65% restante para otros fines.
 
 ```python
 from sklearn.datasets import load_iris
 from sklearn.model_selection import train_test_split
-from InsideForest import InsideForest
+from InsideForest import InsideForestClassifier, InsideForestRegressor
 
 iris = load_iris()
 X, y = iris.data, iris.target
@@ -63,7 +64,7 @@ X_train, X_rest, y_train, y_rest = train_test_split(
     X, y, train_size=0.35, stratify=y, random_state=15
 )
 
-in_f = InsideForest(
+in_f = InsideForestClassifier(
     rf_params={"random_state": 15},
     tree_params={"mode": "py", "n_sample_multiplier": 0.05, "ef_sample_multiplier": 10},
 )

--- a/README.md
+++ b/README.md
@@ -44,16 +44,17 @@ The typical order for applying InsideForest is:
 5. Optionally interpret results with `generate_descriptions` and `categorize_conditions`.
 6. Finally, use helpers such as `Models` and `Labels` for further analysis.
 
-## InsideForest wrapper
-For a simplified workflow you can use the `InsideForest` class, which combines
-the random forest training and region labeling steps:
+## InsideForestClassifier and InsideForestRegressor wrappers
+For a simplified workflow you can use the `InsideForestClassifier` or
+`InsideForestRegressor` classes, which combine the random forest training and
+region labeling steps:
 
 Note: InsideForest is typically run on a subset of the data, for example using 35% of the observations and reserving the remaining 65% for other purposes.
 
 ```python
 from sklearn.datasets import load_iris
 from sklearn.model_selection import train_test_split
-from InsideForest import InsideForest
+from InsideForest import InsideForestClassifier, InsideForestRegressor
 
 iris = load_iris()
 X, y = iris.data, iris.target
@@ -63,7 +64,7 @@ X_train, X_rest, y_train, y_rest = train_test_split(
     X, y, train_size=0.35, stratify=y, random_state=15
 )
 
-in_f = InsideForest(
+in_f = InsideForestClassifier(
     rf_params={"random_state": 15},
     tree_params={"mode": "py", "n_sample_multiplier": 0.05, "ef_sample_multiplier": 10},
 )

--- a/tests/test_inside_forest_regressor_fit_predict.py
+++ b/tests/test_inside_forest_regressor_fit_predict.py
@@ -4,15 +4,15 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import pandas as pd
 import numpy as np
 import pytest
-from sklearn.ensemble import RandomForestClassifier
+from sklearn.ensemble import RandomForestRegressor
 
-from InsideForest import InsideForestClassifier
+from InsideForest import InsideForestRegressor
 
 
 def test_inside_forest_fit_predict_runs():
-    X = pd.DataFrame(data={'feat1': [0, 1, 2, 3], 'feat2': [3, 2, 1, 0]})
-    y = [0, 1, 0, 1]
-    model = InsideForestClassifier(rf_params={'n_estimators': 5, 'random_state': 0})
+    X = pd.DataFrame(data={"feat1": [0, 1, 2, 3], "feat2": [3, 2, 1, 0]})
+    y = [0.1, 0.2, 0.3, 0.4]
+    model = InsideForestRegressor(rf_params={"n_estimators": 5, "random_state": 0})
     fitted = model.fit(X=X, y=y)
     assert fitted is model
     preds = model.predict(X=X)
@@ -21,27 +21,29 @@ def test_inside_forest_fit_predict_runs():
 
 
 def test_predict_before_fit_raises():
-    model = InsideForestClassifier()
-    X = pd.DataFrame(data={'feat1': [0], 'feat2': [0]})
+    model = InsideForestRegressor()
+    X = pd.DataFrame(data={"feat1": [0], "feat2": [0]})
     with pytest.raises(RuntimeError):
         model.predict(X=X)
 
 
 def test_fit_accepts_df_with_target_column():
-    df = pd.DataFrame(data={
-        'feat1': [0, 1, 2, 3],
-        'feat2': [3, 2, 1, 0],
-        'target': [0, 1, 0, 1]
-    })
-    model = InsideForestClassifier(rf_params={'n_estimators': 5, 'random_state': 0})
+    df = pd.DataFrame(
+        data={
+            "feat1": [0, 1, 2, 3],
+            "feat2": [3, 2, 1, 0],
+            "target": [0.1, 0.2, 0.3, 0.4],
+        }
+    )
+    model = InsideForestRegressor(rf_params={"n_estimators": 5, "random_state": 0})
     fitted = model.fit(X=df)
     assert fitted is model
     assert model.labels_.shape[0] == len(df)
 
 
 def test_fit_df_missing_target_raises():
-    df = pd.DataFrame(data={'feat1': [0, 1], 'feat2': [1, 0]})
-    model = InsideForestClassifier()
+    df = pd.DataFrame(data={"feat1": [0, 1], "feat2": [1, 0]})
+    model = InsideForestRegressor()
     with pytest.raises(ValueError):
         model.fit(X=df)
 
@@ -49,13 +51,13 @@ def test_fit_df_missing_target_raises():
 def test_custom_label_and_frontier_params():
     df = pd.DataFrame(
         data={
-            'feat1': [0, 1, 2, 3],
-            'feat2': [3, 2, 1, 0],
-            'target': [0, 1, 0, 1],
+            "feat1": [0, 1, 2, 3],
+            "feat2": [3, 2, 1, 0],
+            "target": [0.1, 0.2, 0.3, 0.4],
         }
     )
-    model = InsideForestClassifier(
-        rf_params={'n_estimators': 5, 'random_state': 0},
+    model = InsideForestRegressor(
+        rf_params={"n_estimators": 5, "random_state": 0},
         n_clusters=2,
         include_summary_cluster=True,
         balanced=True,
@@ -70,10 +72,10 @@ def test_custom_label_and_frontier_params():
 
 
 def test_fit_accepts_custom_rf_instance():
-    X = pd.DataFrame(data={'feat1': [0, 1, 2, 3], 'feat2': [3, 2, 1, 0]})
-    y = [0, 1, 0, 1]
-    rf = RandomForestClassifier(n_estimators=5, random_state=0)
-    model = InsideForestClassifier()
+    X = pd.DataFrame(data={"feat1": [0, 1, 2, 3], "feat2": [3, 2, 1, 0]})
+    y = [0.1, 0.2, 0.3, 0.4]
+    rf = RandomForestRegressor(n_estimators=5, random_state=0)
+    model = InsideForestRegressor()
     fitted = model.fit(X=X, y=y, rf=rf)
     assert fitted is model
     assert model.rf is rf
@@ -83,7 +85,7 @@ def test_fit_accepts_custom_rf_instance():
 
 
 def test_fit_accepts_trained_rf_without_refitting():
-    class TrackingRF(RandomForestClassifier):
+    class TrackingRF(RandomForestRegressor):
         def __init__(self, **kwargs):
             super().__init__(**kwargs)
             self.fit_calls = 0
@@ -92,13 +94,13 @@ def test_fit_accepts_trained_rf_without_refitting():
             self.fit_calls += 1
             return super().fit(X, y, **kwargs)
 
-    X = pd.DataFrame(data={'feat1': [0, 1, 2, 3], 'feat2': [3, 2, 1, 0]})
-    y = [0, 1, 0, 1]
+    X = pd.DataFrame(data={"feat1": [0, 1, 2, 3], "feat2": [3, 2, 1, 0]})
+    y = [0.1, 0.2, 0.3, 0.4]
     rf = TrackingRF(n_estimators=5, random_state=0)
     rf.fit(X, y)
     assert rf.fit_calls == 1
 
-    model = InsideForestClassifier()
+    model = InsideForestRegressor()
     fitted = model.fit(X=X, y=y, rf=rf)
     assert fitted is model
     assert model.rf is rf
@@ -107,3 +109,4 @@ def test_fit_accepts_trained_rf_without_refitting():
     preds = model.predict(X=X)
     assert preds.shape == (4,)
     assert np.array_equal(preds, model.labels_)
+


### PR DESCRIPTION
## Summary
- add internal base class and new InsideForestRegressor wrapper using RandomForestRegressor
- export InsideForestRegressor and update docs
- handle regression tree values and add regression test coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896c98af510832cac50bdf3035a3879