### PR TITLE
Add joblib-based save/load for InsideForest models

### DIFF
--- a/InsideForest/inside_forest.py
+++ b/InsideForest/inside_forest.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import joblib
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.validation import check_is_fitted
@@ -191,6 +192,67 @@ class _BaseInsideForest:
         )
         df_clusterizado["cluster"] = df_clusterizado["cluster"].fillna(value=-1)
         return df_clusterizado["cluster"].to_numpy()
+
+    def save(self, filepath: str):
+        """Save the fitted model and derived attributes to ``filepath``.
+
+        Parameters
+        ----------
+        filepath : str
+            Destination path where the model will be serialized.
+        """
+
+        payload = {
+            "rf": self.rf,
+            "rf_params": self.rf_params,
+            "tree_params": self.tree_params,
+            "var_obj": self.var_obj,
+            "n_clusters": self.n_clusters,
+            "include_summary_cluster": self.include_summary_cluster,
+            "balanced": self.balanced,
+            "divide": self.divide,
+            "labels_": self.labels_,
+            "feature_names_": self.feature_names_,
+            "df_clusters_descript_": self.df_clusters_descript_,
+            "df_reres_": self.df_reres_,
+            "df_datos_explain_": self.df_datos_explain_,
+            "frontiers_": self.frontiers_,
+        }
+        joblib.dump(payload, filepath)
+
+    @classmethod
+    def load(cls, filepath: str):
+        """Load a previously saved InsideForest model from ``filepath``.
+
+        Parameters
+        ----------
+        filepath : str
+            Path to the serialized model file.
+
+        Returns
+        -------
+        Instance of ``cls``
+            Restored model with fitted attributes.
+        """
+
+        payload = joblib.load(filepath)
+        model = cls(
+            rf_params=payload["rf_params"],
+            tree_params=payload["tree_params"],
+            var_obj=payload["var_obj"],
+            n_clusters=payload["n_clusters"],
+            include_summary_cluster=payload["include_summary_cluster"],
+            balanced=payload["balanced"],
+            divide=payload["divide"],
+        )
+        model.rf = payload["rf"]
+        model.labels_ = payload["labels_"]
+        model.feature_names_ = payload["feature_names_"]
+        model.df_clusters_descript_ = payload["df_clusters_descript_"]
+        model.df_reres_ = payload["df_reres_"]
+        model.df_datos_explain_ = payload["df_datos_explain_"]
+        model.frontiers_ = payload["frontiers_"]
+        return model
 
 
 class InsideForestClassifier(_BaseInsideForest):

--- a/README.es.md
+++ b/README.es.md
@@ -74,6 +74,20 @@ pred_labels = in_f.predict(X_rest)  # etiquetas de cluster para los datos restan
 etiquetas_entrenamiento = in_f.labels_  # etiquetas para el subconjunto de entrenamiento
 ```
 
+### Guardar y cargar modelos
+
+Las clases `InsideForestClassifier` e `InsideForestRegressor` incluyen
+métodos para persistir un modelo entrenado utilizando `joblib`:
+
+```python
+in_f.save("modelo.joblib")
+cargado = InsideForestClassifier.load("modelo.joblib")
+```
+
+El modelo cargado restaura el bosque aleatorio y los atributos
+calculados, permitiendo continuar generando etiquetas o predicciones
+sin volver a entrenar.
+
 ## Caso de uso (Iris)
 Lo siguiente resume el flujo utilizado en el [notebook de ejemplo](https://colab.research.google.com/drive/11VGeB0V6PLMlQ8Uhba91fJ4UN1Bfbs90?usp=sharing).
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ pred_labels = in_f.predict(X_rest)  # cluster labels for the remaining data
 training_labels = in_f.labels_  # labels for the training subset
 ```
 
+### Saving and loading models
+
+Both `InsideForestClassifier` and `InsideForestRegressor` include
+convenience methods to persist a fitted instance using `joblib`:
+
+```python
+in_f.save("model.joblib")
+loaded = InsideForestClassifier.load("model.joblib")
+```
+
+The loaded model restores the underlying random forest and computed
+attributes, allowing you to continue generating labels or predictions
+without re-fitting.
+
 ## Use case (Iris)
 The following summarizes the flow used in the [example notebook](https://colab.research.google.com/drive/11VGeB0V6PLMlQ8Uhba91fJ4UN1Bfbs90?usp=sharing).
 

--- a/tests/test_inside_forest_fit_predict.py
+++ b/tests/test_inside_forest_fit_predict.py
@@ -107,3 +107,19 @@ def test_fit_accepts_trained_rf_without_refitting():
     preds = model.predict(X=X)
     assert preds.shape == (4,)
     assert np.array_equal(preds, model.labels_)
+
+
+def test_save_and_load_roundtrip(tmp_path):
+    X = pd.DataFrame(data={'feat1': [0, 1, 2, 3], 'feat2': [3, 2, 1, 0]})
+    y = [0, 1, 0, 1]
+    model = InsideForestClassifier(rf_params={'n_estimators': 5, 'random_state': 0})
+    model.fit(X=X, y=y)
+    preds = model.predict(X=X)
+    filepath = tmp_path / 'clf.joblib'
+    model.save(str(filepath))
+
+    loaded = InsideForestClassifier.load(str(filepath))
+    loaded_preds = loaded.predict(X=X)
+
+    assert np.array_equal(model.labels_, loaded.labels_)
+    assert np.array_equal(preds, loaded_preds)

--- a/tests/test_inside_forest_regressor_fit_predict.py
+++ b/tests/test_inside_forest_regressor_fit_predict.py
@@ -110,3 +110,19 @@ def test_fit_accepts_trained_rf_without_refitting():
     assert preds.shape == (4,)
     assert np.array_equal(preds, model.labels_)
 
+
+def test_save_and_load_roundtrip(tmp_path):
+    X = pd.DataFrame(data={"feat1": [0, 1, 2, 3], "feat2": [3, 2, 1, 0]})
+    y = [0.1, 0.2, 0.3, 0.4]
+    model = InsideForestRegressor(rf_params={"n_estimators": 5, "random_state": 0})
+    model.fit(X=X, y=y)
+    preds = model.predict(X=X)
+    filepath = tmp_path / "reg.joblib"
+    model.save(str(filepath))
+
+    loaded = InsideForestRegressor.load(str(filepath))
+    loaded_preds = loaded.predict(X=X)
+
+    assert np.array_equal(model.labels_, loaded.labels_)
+    assert np.array_equal(preds, loaded_preds)
+


### PR DESCRIPTION
## Summary
- allow InsideForest models to be saved and loaded with `joblib`, restoring fitted estimators and derived attributes
- document new `save`/`load` helpers in both English and Spanish READMEs
- test serialization round-trips for classifier and regressor wrappers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896ce21c594832cae386c0493e3b212