### PR TITLE
Expose and visualize feature importances

### DIFF
--- a/InsideForest/inside_forest.py
+++ b/InsideForest/inside_forest.py
@@ -12,6 +12,10 @@ from .descrip import get_frontiers
 class _BaseInsideForest:
     """Internal base class handling shared ``fit`` and ``predict`` logic.
 
+    After fitting, the random forest's feature importances can be inspected
+    via the :attr:`feature_importances_` property or visualized with the
+    :meth:`plot_importances` method.
+
     Parameters
     ----------
     rf_cls : type
@@ -155,6 +159,52 @@ class _BaseInsideForest:
         self.frontiers_ = frontiers
 
         return self
+
+    @property
+    def feature_importances_(self):
+        """Feature importances of the fitted random forest.
+
+        Returns
+        -------
+        ndarray of shape (n_features,)
+            Importance of each feature as computed by the underlying random
+            forest.
+
+        Raises
+        ------
+        NotFittedError
+            If the internal random forest has not been fitted yet.
+        """
+
+        check_is_fitted(self.rf)
+        return self.rf.feature_importances_
+
+    def plot_importances(self):
+        """Plot feature importances of the underlying random forest.
+
+        Returns
+        -------
+        matplotlib.axes.Axes
+            Axes object containing a bar chart of feature importances.
+        """
+
+        check_is_fitted(self.rf)
+
+        import numpy as np
+        import matplotlib.pyplot as plt
+
+        importances = self.rf.feature_importances_
+        indices = np.argsort(importances)[::-1]
+        feature_names = [self.feature_names_[i] for i in indices]
+
+        fig, ax = plt.subplots()
+        ax.bar(range(len(importances)), importances[indices])
+        ax.set_xticks(range(len(importances)))
+        ax.set_xticklabels(feature_names, rotation=90)
+        ax.set_ylabel("Feature importance")
+        ax.set_title("Feature importances")
+        fig.tight_layout()
+        return ax
 
     def predict(self, X):
         """Assign cluster labels to new data based on learned regions.

--- a/README.es.md
+++ b/README.es.md
@@ -74,6 +74,14 @@ pred_labels = in_f.predict(X_rest)  # etiquetas de cluster para los datos restan
 etiquetas_entrenamiento = in_f.labels_  # etiquetas para el subconjunto de entrenamiento
 ```
 
+Después del ajuste, puedes consultar las importancias de las variables del
+bosque aleatorio y visualizarlas opcionalmente:
+
+```python
+importancias = in_f.feature_importances_
+ejes = in_f.plot_importances()
+```
+
 ### Guardar y cargar modelos
 
 Las clases `InsideForestClassifier` e `InsideForestRegressor` incluyen

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ pred_labels = in_f.predict(X_rest)  # cluster labels for the remaining data
 training_labels = in_f.labels_  # labels for the training subset
 ```
 
+After fitting, you can inspect the random forest's feature importances and
+optionally visualize them:
+
+```python
+importances = in_f.feature_importances_
+ax = in_f.plot_importances()
+```
+
 ### Saving and loading models
 
 Both `InsideForestClassifier` and `InsideForestRegressor` include

--- a/tests/test_inside_forest_fit_predict.py
+++ b/tests/test_inside_forest_fit_predict.py
@@ -123,3 +123,19 @@ def test_save_and_load_roundtrip(tmp_path):
 
     assert np.array_equal(model.labels_, loaded.labels_)
     assert np.array_equal(preds, loaded_preds)
+
+
+def test_feature_importances_and_plot():
+    X = pd.DataFrame(data={"feat1": [0, 1, 2, 3], "feat2": [3, 2, 1, 0]})
+    y = [0, 1, 0, 1]
+    model = InsideForestClassifier(rf_params={"n_estimators": 5, "random_state": 0})
+    model.fit(X=X, y=y)
+
+    importances = model.feature_importances_
+    assert isinstance(importances, np.ndarray)
+    assert importances.shape[0] == X.shape[1]
+
+    import matplotlib.axes
+
+    ax = model.plot_importances()
+    assert isinstance(ax, matplotlib.axes.Axes)

--- a/tests/test_inside_forest_regressor_fit_predict.py
+++ b/tests/test_inside_forest_regressor_fit_predict.py
@@ -126,3 +126,19 @@ def test_save_and_load_roundtrip(tmp_path):
     assert np.array_equal(model.labels_, loaded.labels_)
     assert np.array_equal(preds, loaded_preds)
 
+
+def test_feature_importances_and_plot():
+    X = pd.DataFrame(data={"feat1": [0, 1, 2, 3], "feat2": [3, 2, 1, 0]})
+    y = [0.1, 0.2, 0.3, 0.4]
+    model = InsideForestRegressor(rf_params={"n_estimators": 5, "random_state": 0})
+    model.fit(X=X, y=y)
+
+    importances = model.feature_importances_
+    assert isinstance(importances, np.ndarray)
+    assert importances.shape[0] == X.shape[1]
+
+    import matplotlib.axes
+
+    ax = model.plot_importances()
+    assert isinstance(ax, matplotlib.axes.Axes)
+


### PR DESCRIPTION
## Summary
- expose `feature_importances_` on InsideForest models
- add `plot_importances()` helper for visualizing feature relevance
- document feature importance access in English and Spanish READMEs

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896cfe42378832c9f77a67b113ca2d8