### PR TITLE
Add scikit-learn compatible parameter helpers

### DIFF
--- a/InsideForest/inside_forest.py
+++ b/InsideForest/inside_forest.py
@@ -67,6 +67,74 @@ class _BaseInsideForest:
         self.df_datos_explain_ = None
         self.frontiers_ = None
 
+    def get_params(self, deep=True):
+        """Return estimator parameters.
+
+        Parameters
+        ----------
+        deep : bool, default=True
+            Included for API compatibility. Has no effect in this
+            implementation but mirrors scikit-learn's ``BaseEstimator``.
+
+        Returns
+        -------
+        dict
+            Mapping of parameter names to their values.
+        """
+
+        return {
+            "rf_params": self.rf_params,
+            "tree_params": self.tree_params,
+            "var_obj": self.var_obj,
+            "n_clusters": self.n_clusters,
+            "include_summary_cluster": self.include_summary_cluster,
+            "balanced": self.balanced,
+            "divide": self.divide,
+        }
+
+    def set_params(self, **params):
+        """Set estimator parameters.
+
+        Parameters
+        ----------
+        **params : dict
+            Estimator parameters to update. Keys corresponding to ``rf``
+            can be provided either as ``rf_params`` (a complete dict) or
+            using the ``rf__<param>`` notation familiar from scikit-learn.
+
+        Returns
+        -------
+        self
+        """
+
+        for key, value in params.items():
+            if key == "rf_params":
+                self.rf_params = value
+                self.rf.set_params(**self.rf_params)
+            elif key.startswith("rf__"):
+                sub_key = key.split("__", 1)[1]
+                self.rf_params[sub_key] = value
+                self.rf.set_params(**{sub_key: value})
+            elif key == "tree_params":
+                self.tree_params = value
+                self.trees = Trees(**self.tree_params)
+            elif key.startswith("tree_params__"):
+                sub_key = key.split("__", 1)[1]
+                self.tree_params[sub_key] = value
+                self.trees = Trees(**self.tree_params)
+            elif key in {
+                "var_obj",
+                "n_clusters",
+                "include_summary_cluster",
+                "balanced",
+                "divide",
+            }:
+                setattr(self, key, value)
+            else:
+                raise ValueError(f"Invalid parameter '{key}'")
+
+        return self
+
     def fit(self, X, y=None, rf=None):
         """Fit the internal random forest and compute cluster labels.
 

--- a/tests/test_inside_forest_params.py
+++ b/tests/test_inside_forest_params.py
@@ -1,0 +1,41 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+
+from InsideForest import InsideForestClassifier
+
+
+def test_get_params_returns_init_values():
+    model = InsideForestClassifier(
+        rf_params={"n_estimators": 5},
+        tree_params={"lang": "python"},
+        n_clusters=2,
+        include_summary_cluster=True,
+        balanced=True,
+        divide=3,
+    )
+    params = model.get_params()
+    assert params["rf_params"]["n_estimators"] == 5
+    assert params["tree_params"]["lang"] == "python"
+    assert params["n_clusters"] == 2
+    assert params["include_summary_cluster"] is True
+    assert params["balanced"] is True
+    assert params["divide"] == 3
+
+
+def test_set_params_updates_attributes():
+    model = InsideForestClassifier(rf_params={"n_estimators": 5})
+    model.set_params(rf_params={"n_estimators": 3})
+    assert model.rf_params["n_estimators"] == 3
+    assert model.rf.get_params()["n_estimators"] == 3
+
+    model.set_params(rf__max_depth=4)
+    assert model.rf_params["max_depth"] == 4
+    assert model.rf.get_params()["max_depth"] == 4
+
+    model.set_params(n_clusters=7)
+    assert model.n_clusters == 7
+
+    with pytest.raises(ValueError):
+        model.set_params(unknown=1)


### PR DESCRIPTION
## Summary
- expose estimator configuration via new `get_params`
- allow updating parameters and nested random forest options with `set_params`
- cover parameter helpers with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896cffd9dc4832c83a9fa90e313e4ce