### PR TITLE
Add score method with normalization and tests

### DIFF
--- a/InsideForest/inside_forest.py
+++ b/InsideForest/inside_forest.py
@@ -193,6 +193,41 @@ class _BaseInsideForest:
         df_clusterizado["cluster"] = df_clusterizado["cluster"].fillna(value=-1)
         return df_clusterizado["cluster"].to_numpy()
 
+    def score(self, X, y):
+        """Compute the underlying forest's score on the provided data.
+
+        This delegates to :meth:`self.rf.score` after applying the same
+        column normalization performed in :meth:`predict`. The exact metric
+        returned depends on the type of the wrapped random forest (e.g.,
+        accuracy for classifiers or :math:`R^2` for regressors).
+
+        Parameters
+        ----------
+        X : array-like or pandas.DataFrame
+            Feature matrix. If a DataFrame is given, its columns are renamed
+            by replacing spaces with underscores and re-ordered to match the
+            training data.
+        y : array-like
+            Target vector.
+
+        Returns
+        -------
+        float
+            Score computed by the underlying random forest estimator.
+        """
+
+        if self.feature_names_ is None:
+            raise RuntimeError("InsideForest instance is not fitted yet")
+
+        if isinstance(X, pd.DataFrame):
+            X_df = X.copy()
+            X_df.columns = [str(c).replace(" ", "_") for c in X_df.columns]
+            X_df = X_df[self.feature_names_]
+        else:
+            X_df = pd.DataFrame(data=X, columns=self.feature_names_)
+
+        return self.rf.score(X_df, y)
+
     def save(self, filepath: str):
         """Save the fitted model and derived attributes to ``filepath``.
 

--- a/tests/test_inside_forest_fit_predict.py
+++ b/tests/test_inside_forest_fit_predict.py
@@ -123,3 +123,19 @@ def test_save_and_load_roundtrip(tmp_path):
 
     assert np.array_equal(model.labels_, loaded.labels_)
     assert np.array_equal(preds, loaded_preds)
+
+
+def test_score_normalizes_dataframe_like_predict():
+    X = pd.DataFrame(data={"feat 1": [0, 1, 2, 3], "feat 2": [3, 2, 1, 0]})
+    y = [0, 1, 0, 1]
+    model = InsideForestClassifier(rf_params={"n_estimators": 5, "random_state": 0})
+    model.fit(X=X, y=y)
+
+    # Reorder columns and keep spaces to exercise normalization logic
+    X_test = X[["feat 2", "feat 1"]]
+    score = model.score(X_test, y)
+
+    X_norm = X.copy()
+    X_norm.columns = ["feat_1", "feat_2"]
+    expected = model.rf.score(X_norm, y)
+    assert score == pytest.approx(expected)

--- a/tests/test_inside_forest_regressor_fit_predict.py
+++ b/tests/test_inside_forest_regressor_fit_predict.py
@@ -126,3 +126,18 @@ def test_save_and_load_roundtrip(tmp_path):
     assert np.array_equal(model.labels_, loaded.labels_)
     assert np.array_equal(preds, loaded_preds)
 
+
+def test_score_normalizes_dataframe_like_predict():
+    X = pd.DataFrame(data={"feat 1": [0, 1, 2, 3], "feat 2": [3, 2, 1, 0]})
+    y = [0.1, 0.2, 0.3, 0.4]
+    model = InsideForestRegressor(rf_params={"n_estimators": 5, "random_state": 0})
+    model.fit(X=X, y=y)
+
+    X_test = X[["feat 2", "feat 1"]]
+    score = model.score(X_test, y)
+
+    X_norm = X.copy()
+    X_norm.columns = ["feat_1", "feat_2"]
+    expected = model.rf.score(X_norm, y)
+    assert score == pytest.approx(expected)
+


### PR DESCRIPTION
## Summary
- Add `score` method to `_BaseInsideForest` that normalizes input like `predict` and delegates to the underlying random forest
- Document that returned metric depends on the type of wrapped random forest
- Test scoring for classifier and regressor ensuring column normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d0532d0c832c8e71ef971bf2f88f