### PR TITLE
Add score method with normalization and tests

### DIFF
--- a/InsideForest/inside_forest.py
+++ b/InsideForest/inside_forest.py
@@ -311,6 +311,40 @@ class _BaseInsideForest:
         df_clusterizado["cluster"] = df_clusterizado["cluster"].fillna(value=-1)
         return df_clusterizado["cluster"].to_numpy()
 
+    def score(self, X, y):
+        """Return the score of the underlying random forest on the given data.
+
+        The metric reported depends on the type of wrapped random forest
+        estimator. For classifiers this is the mean accuracy, while for
+        regressors it corresponds to :math:`R^2`.
+
+        Parameters
+        ----------
+        X : array-like or pandas.DataFrame
+            Feature matrix. If a DataFrame is provided, columns are normalized
+            and reordered to match the training data.
+        y : array-like
+            Ground truth target values.
+
+        Returns
+        -------
+        float
+            Score as computed by :meth:`sklearn.ensemble.RandomForestRegressor.score`
+            or :meth:`sklearn.ensemble.RandomForestClassifier.score` depending on
+            the estimator type.
+        """
+
+        check_is_fitted(self.rf)
+
+        if isinstance(X, pd.DataFrame):
+            X_df = X.copy()
+            X_df.columns = [str(c).replace(" ", "_") for c in X_df.columns]
+            X_df = X_df[self.feature_names_]
+        else:
+            X_df = pd.DataFrame(data=X, columns=self.feature_names_)
+
+        return self.rf.score(X_df, y)
+
     def save(self, filepath: str):
         """Save the fitted model and derived attributes to ``filepath``.
 

--- a/tests/test_inside_forest_fit_predict.py
+++ b/tests/test_inside_forest_fit_predict.py
@@ -139,3 +139,16 @@ def test_feature_importances_and_plot():
 
     ax = model.plot_importances()
     assert isinstance(ax, matplotlib.axes.Axes)
+
+
+def test_score_matches_rf_and_normalizes_input():
+    X = pd.DataFrame(data={"feat 1": [0, 1, 2, 3], "feat 2": [3, 2, 1, 0]})
+    y = [0, 1, 0, 1]
+    model = InsideForestClassifier(rf_params={"n_estimators": 5, "random_state": 0})
+    model.fit(X=X, y=y)
+
+    X_messy = X[["feat 2", "feat 1"]]
+    X_norm = X.copy()
+    X_norm.columns = [c.replace(" ", "_") for c in X_norm.columns]
+    expected = model.rf.score(X_norm, y)
+    assert model.score(X_messy, y) == expected

--- a/tests/test_inside_forest_regressor_fit_predict.py
+++ b/tests/test_inside_forest_regressor_fit_predict.py
@@ -142,3 +142,16 @@ def test_feature_importances_and_plot():
     ax = model.plot_importances()
     assert isinstance(ax, matplotlib.axes.Axes)
 
+
+def test_score_matches_rf_and_normalizes_input():
+    X = pd.DataFrame(data={"feat 1": [0, 1, 2, 3], "feat 2": [3, 2, 1, 0]})
+    y = [0.1, 0.2, 0.3, 0.4]
+    model = InsideForestRegressor(rf_params={"n_estimators": 5, "random_state": 0})
+    model.fit(X=X, y=y)
+
+    X_messy = X[["feat 2", "feat 1"]]
+    X_norm = X.copy()
+    X_norm.columns = [c.replace(" ", "_") for c in X_norm.columns]
+    expected = model.rf.score(X_norm, y)
+    assert model.score(X_messy, y) == pytest.approx(expected)
+


### PR DESCRIPTION
## Summary
- add `score` method to `_BaseInsideForest` that normalizes inputs and calls the underlying random forest
- document metric depends on classifier vs regressor
- test scoring for both classifier and regressor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d300b948832ca3fe474a7b77b879