### PR TITLE
Validate feature columns during prediction

### DIFF
--- a/InsideForest/inside_forest.py
+++ b/InsideForest/inside_forest.py
@@ -296,6 +296,14 @@ class _BaseInsideForest:
         if isinstance(X, pd.DataFrame):
             X_df = X.copy()
             X_df.columns = [str(c).replace(" ", "_") for c in X_df.columns]
+            # Ensure all required columns are present before reordering
+            missing_cols = [c for c in self.feature_names_ if c not in X_df.columns]
+            if missing_cols:
+                missing_str = ", ".join(missing_cols)
+                raise ValueError(
+                    "Input data is missing required feature columns: "
+                    f"{missing_str}. Include these features in 'X' to predict."
+                )
             # Reorder/Subset columns to match training features
             X_df = X_df[self.feature_names_]
         else:

--- a/tests/test_inside_forest_fit_predict.py
+++ b/tests/test_inside_forest_fit_predict.py
@@ -139,3 +139,14 @@ def test_feature_importances_and_plot():
 
     ax = model.plot_importances()
     assert isinstance(ax, matplotlib.axes.Axes)
+
+
+def test_predict_missing_columns_raises():
+    X_train = pd.DataFrame(data={"feat1": [0, 1], "feat2": [1, 0]})
+    y = [0, 1]
+    model = InsideForestClassifier(rf_params={"n_estimators": 5, "random_state": 0})
+    model.fit(X=X_train, y=y)
+
+    X_missing = pd.DataFrame(data={"feat1": [0, 1]})
+    with pytest.raises(ValueError, match="feat2"):
+        model.predict(X=X_missing)


### PR DESCRIPTION
## Summary
- ensure predict raises ValueError when required feature columns are missing
- test missing-column behavior in prediction

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896d32201ec832ca8246ce2e3455bc7