### PR TITLE
Check feature columns in InsideForest.predict

### DIFF
--- a/InsideForest/inside_forest.py
+++ b/InsideForest/inside_forest.py
@@ -296,6 +296,13 @@ class _BaseInsideForest:
         if isinstance(X, pd.DataFrame):
             X_df = X.copy()
             X_df.columns = [str(c).replace(" ", "_") for c in X_df.columns]
+            missing_cols = [col for col in self.feature_names_ if col not in X_df.columns]
+            if missing_cols:
+                missing_str = ", ".join(missing_cols)
+                raise ValueError(
+                    "Missing required feature columns: "
+                    f"{missing_str}. Add these columns or refit the model with the current data."
+                )
             # Reorder/Subset columns to match training features
             X_df = X_df[self.feature_names_]
         else:

--- a/tests/test_inside_forest_fit_predict.py
+++ b/tests/test_inside_forest_fit_predict.py
@@ -27,6 +27,16 @@ def test_predict_before_fit_raises():
         model.predict(X=X)
 
 
+def test_predict_missing_columns_raises():
+    X = pd.DataFrame(data={'feat1': [0, 1, 2, 3], 'feat2': [3, 2, 1, 0]})
+    y = [0, 1, 0, 1]
+    model = InsideForestClassifier(rf_params={'n_estimators': 5, 'random_state': 0})
+    model.fit(X=X, y=y)
+    X_missing = pd.DataFrame(data={'feat1': [0, 1]})
+    with pytest.raises(ValueError, match="feat2"):
+        model.predict(X=X_missing)
+
+
 def test_fit_accepts_df_with_target_column():
     df = pd.DataFrame(data={
         'feat1': [0, 1, 2, 3],

--- a/tests/test_inside_forest_regressor_fit_predict.py
+++ b/tests/test_inside_forest_regressor_fit_predict.py
@@ -27,6 +27,16 @@ def test_predict_before_fit_raises():
         model.predict(X=X)
 
 
+def test_predict_missing_columns_raises():
+    X = pd.DataFrame(data={"feat1": [0, 1, 2, 3], "feat2": [3, 2, 1, 0]})
+    y = [0.1, 0.2, 0.3, 0.4]
+    model = InsideForestRegressor(rf_params={"n_estimators": 5, "random_state": 0})
+    model.fit(X=X, y=y)
+    X_missing = pd.DataFrame(data={"feat1": [0.1, 0.2]})
+    with pytest.raises(ValueError, match="feat2"):
+        model.predict(X=X_missing)
+
+
 def test_fit_accepts_df_with_target_column():
     df = pd.DataFrame(
         data={


### PR DESCRIPTION
## Summary
- validate input DataFrames in `_BaseInsideForest.predict` to ensure all training feature columns are present
- add classifier and regressor tests for missing columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d446f9b0832c8cdf616a5976745a