### PR TITLE
Add benchmarking experiments with baselines

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -208,6 +208,22 @@ regions.plot_experiments(df, experimento, interactive=False)
 
 Compara los clusters A y B usando las reglas de una fila de la tabla de experimentos.
 
+## Experimentos
+
+El módulo `experiments/benchmark.py` ejecuta comparativas de clustering
+supervisado sobre un conjunto de datos de tamaño mediano (`Digits`) y
+otro grande generado sintéticamente. Compara `InsideForest` con
+baselines tradicionales como KMeans y DBSCAN, reportando pureza,
+F1 macro y tiempo de ejecución. También incluye un análisis de
+sensibilidad para los hiperparámetros clave: `K` en KMeans y
+`eps`/`min_samples` en DBSCAN.
+
+Ejecuta el script con:
+
+```
+python -m experiments.benchmark
+```
+
 ## Licencia
 
 Este proyecto se distribuye bajo la licencia MIT. Consulta [LICENSE](LICENSE) para más detalles.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,22 @@ regions.plot_experiments(df, experiment, interactive=False)
 
 Compares clusters A and B using the rules provided by a row from the experiments table.
 
+## Experiments
+
+The `experiments/benchmark.py` module runs supervised clustering
+benchmarks on a medium sized dataset (`Digits`) and on a synthetically
+generated large dataset. It compares `InsideForest` with traditional
+baselines like KMeans and DBSCAN, reporting purity, macro F1-score and
+runtime for each method. It also performs a basic sensitivity analysis
+on key hyperparameters: `K` for KMeans and `eps`/`min_samples` for
+DBSCAN.
+
+Execute the script with:
+
+```
+python -m experiments.benchmark
+```
+
 ## License
 
 This project is distributed under the MIT license. See [LICENSE](LICENSE) for details.

--- a/experiments/benchmark.py
+++ b/experiments/benchmark.py
@@ -1,0 +1,159 @@
+"""Benchmark supervised clustering algorithms on multiple datasets.
+
+This script evaluates InsideForest against traditional baselines on two datasets:
+- Digits (medium sized, 1,797 samples)
+- Synthetic large classification dataset (10,000 samples)
+
+For each dataset we report purity, macro F1-score and runtime. Baselines
+include KMeans and DBSCAN. A basic sensitivity analysis is also provided for
+key hyperparameters: the number of clusters ``K`` for KMeans and ``eps`` /
+``min_samples`` for DBSCAN.
+
+The script is meant to be executed as a module:
+
+```
+python -m experiments.benchmark
+```
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Dict, Iterable, Tuple
+
+import numpy as np
+import pandas as pd
+from scipy.optimize import linear_sum_assignment
+from sklearn import metrics
+from sklearn.cluster import DBSCAN, KMeans
+from sklearn.datasets import load_digits, make_classification
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+
+from InsideForest import InsideForestClassifier
+
+
+@dataclass
+class Result:
+    """Holds evaluation metrics for a single run."""
+
+    algorithm: str
+    purity: float
+    f1: float
+    runtime: float
+
+    def as_dict(self) -> Dict[str, float]:
+        return {
+            "algorithm": self.algorithm,
+            "purity": self.purity,
+            "f1": self.f1,
+            "runtime": self.runtime,
+        }
+
+
+def _purity_score(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    """Compute clustering purity."""
+
+    contingency = metrics.cluster.contingency_matrix(y_true, y_pred)
+    return np.sum(np.max(contingency, axis=0)) / np.sum(contingency)
+
+
+def _f1_score(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    """Align cluster labels with true labels and compute macro F1."""
+
+    contingency = metrics.cluster.contingency_matrix(y_true, y_pred)
+    row_ind, col_ind = linear_sum_assignment(-contingency)
+    mapping = {col: row for row, col in zip(row_ind, col_ind)}
+    aligned = np.array([mapping.get(c, c) for c in y_pred])
+    return metrics.f1_score(y_true, aligned, average="macro")
+
+
+def _evaluate(y_true: np.ndarray, y_pred: np.ndarray, runtime: float, name: str) -> Result:
+    return Result(name, _purity_score(y_true, y_pred), _f1_score(y_true, y_pred), runtime)
+
+
+def _run_insideforest(X: np.ndarray, y: np.ndarray) -> Result:
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, train_size=0.35, stratify=y, random_state=42
+    )
+    clf = InsideForestClassifier(rf_params={"random_state": 42})
+    start = time.time()
+    clf.fit(X_train, y_train)
+    preds = clf.predict(X_test)
+    runtime = time.time() - start
+    return _evaluate(y_test, preds, runtime, "InsideForest")
+
+
+def _run_kmeans(X: np.ndarray, y: np.ndarray, k: int) -> Result:
+    start = time.time()
+    km = KMeans(n_clusters=k, n_init="auto", random_state=42)
+    preds = km.fit_predict(X)
+    runtime = time.time() - start
+    return _evaluate(y, preds, runtime, f"KMeans(k={k})")
+
+
+def _run_dbscan(X: np.ndarray, y: np.ndarray, eps: float, min_samples: int) -> Result:
+    start = time.time()
+    db = DBSCAN(eps=eps, min_samples=min_samples)
+    preds = db.fit_predict(X)
+    runtime = time.time() - start
+    return _evaluate(y, preds, runtime, f"DBSCAN(eps={eps},min={min_samples})")
+
+
+def _sensitivity_kmeans(X: np.ndarray, y: np.ndarray, ks: Iterable[int]) -> pd.DataFrame:
+    rows = [_run_kmeans(X, y, k).as_dict() for k in ks]
+    return pd.DataFrame(rows)
+
+
+def _sensitivity_dbscan(
+    X: np.ndarray, y: np.ndarray, eps_values: Iterable[float], min_samples_values: Iterable[int]
+) -> pd.DataFrame:
+    rows = []
+    for eps in eps_values:
+        for min_samples in min_samples_values:
+            rows.append(_run_dbscan(X, y, eps, min_samples).as_dict())
+    return pd.DataFrame(rows)
+
+
+def _scale(X: np.ndarray) -> np.ndarray:
+    return StandardScaler().fit_transform(X)
+
+
+def benchmark_dataset(name: str, X: np.ndarray, y: np.ndarray) -> None:
+    print(f"\n=== Dataset: {name} ===")
+    results = []
+    results.append(_run_insideforest(X, y).as_dict())
+    k = len(np.unique(y))
+    results.append(_run_kmeans(X, y, k).as_dict())
+    results.append(_run_dbscan(X, y, eps=0.5, min_samples=5).as_dict())
+    print(pd.DataFrame(results))
+
+    print("\nSensitivity analysis - KMeans")
+    print(_sensitivity_kmeans(X, y, ks=[max(2, k - 1), k, k + 1]))
+    print("\nSensitivity analysis - DBSCAN")
+    print(
+        _sensitivity_dbscan(
+            X, y, eps_values=[0.3, 0.5, 0.7], min_samples_values=[5, 10]
+        )
+    )
+
+
+def main() -> None:
+    digits_X, digits_y = load_digits(return_X_y=True)
+    digits_X = _scale(digits_X)
+    benchmark_dataset("Digits", digits_X, digits_y)
+
+    X_large, y_large = make_classification(
+        n_samples=10000,
+        n_features=20,
+        n_informative=10,
+        n_classes=5,
+        random_state=42,
+    )
+    X_large = _scale(X_large)
+    benchmark_dataset("SyntheticLarge", X_large, y_large)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add experiments/benchmark.py script to compare InsideForest with KMeans and DBSCAN on medium and large datasets
- report purity, macro F1 and runtime while probing K, eps and min_samples sensitivity
- document new benchmarking workflow in English and Spanish READMEs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896d3d34c44832c83289e1a81ddf2a3