### PR TITLE
Add column validation for predictions and tests

### DIFF
--- a/InsideForest/inside_forest.py
+++ b/InsideForest/inside_forest.py
@@ -296,6 +296,12 @@ class _BaseInsideForest:
         if isinstance(X, pd.DataFrame):
             X_df = X.copy()
             X_df.columns = [str(c).replace(" ", "_") for c in X_df.columns]
+            # Validate required columns
+            missing = [c for c in self.feature_names_ if c not in X_df.columns]
+            if missing:
+                raise ValueError(
+                    "Missing required columns: " + ", ".join(missing)
+                )
             # Reorder/Subset columns to match training features
             X_df = X_df[self.feature_names_]
         else:
@@ -339,6 +345,11 @@ class _BaseInsideForest:
         if isinstance(X, pd.DataFrame):
             X_df = X.copy()
             X_df.columns = [str(c).replace(" ", "_") for c in X_df.columns]
+            missing = [c for c in self.feature_names_ if c not in X_df.columns]
+            if missing:
+                raise ValueError(
+                    "Missing required columns: " + ", ".join(missing)
+                )
             X_df = X_df[self.feature_names_]
         else:
             X_df = pd.DataFrame(data=X, columns=self.feature_names_)

--- a/tests/test_inside_forest_fit_predict.py
+++ b/tests/test_inside_forest_fit_predict.py
@@ -152,3 +152,27 @@ def test_score_matches_rf_and_normalizes_input():
     X_norm.columns = [c.replace(" ", "_") for c in X_norm.columns]
     expected = model.rf.score(X_norm, y)
     assert model.score(X_messy, y) == expected
+
+
+def test_predict_missing_column_raises_value_error():
+    X = pd.DataFrame(data={"feat1": [0, 1, 2, 3], "feat2": [3, 2, 1, 0]})
+    y = [0, 1, 0, 1]
+    model = InsideForestClassifier(rf_params={"n_estimators": 5, "random_state": 0})
+    model.fit(X=X, y=y)
+
+    X_missing = X.drop(columns=["feat1"])
+    with pytest.raises(ValueError):
+        model.predict(X_missing)
+
+
+def test_predict_ignores_extra_columns():
+    X = pd.DataFrame(data={"feat1": [0, 1, 2, 3], "feat2": [3, 2, 1, 0]})
+    y = [0, 1, 0, 1]
+    model = InsideForestClassifier(rf_params={"n_estimators": 5, "random_state": 0})
+    model.fit(X=X, y=y)
+
+    X_extra = X.copy()
+    X_extra["extra_feat"] = [5, 6, 7, 8]
+    preds_with_extra = model.predict(X_extra)
+    preds = model.predict(X)
+    assert np.array_equal(preds, preds_with_extra)

--- a/tests/test_inside_forest_regressor_fit_predict.py
+++ b/tests/test_inside_forest_regressor_fit_predict.py
@@ -155,3 +155,27 @@ def test_score_matches_rf_and_normalizes_input():
     expected = model.rf.score(X_norm, y)
     assert model.score(X_messy, y) == pytest.approx(expected)
 
+
+def test_predict_missing_column_raises_value_error():
+    X = pd.DataFrame(data={"feat1": [0, 1, 2, 3], "feat2": [3, 2, 1, 0]})
+    y = [0.1, 0.2, 0.3, 0.4]
+    model = InsideForestRegressor(rf_params={"n_estimators": 5, "random_state": 0})
+    model.fit(X=X, y=y)
+
+    X_missing = X.drop(columns=["feat1"])
+    with pytest.raises(ValueError):
+        model.predict(X_missing)
+
+
+def test_predict_ignores_extra_columns():
+    X = pd.DataFrame(data={"feat1": [0, 1, 2, 3], "feat2": [3, 2, 1, 0]})
+    y = [0.1, 0.2, 0.3, 0.4]
+    model = InsideForestRegressor(rf_params={"n_estimators": 5, "random_state": 0})
+    model.fit(X=X, y=y)
+
+    X_extra = X.copy()
+    X_extra["extra_feat"] = [5, 6, 7, 8]
+    preds_with_extra = model.predict(X_extra)
+    preds = model.predict(X)
+    assert np.array_equal(preds, preds_with_extra)
+


### PR DESCRIPTION
## Summary
- validate required feature columns in `predict` and `score`
- test `predict` with missing and extra columns for classifier and regressor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d45a4770832caf481f24511a5ce8