### PR TITLE
Refactor tree range extraction with regex and parallel processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,3 +344,15 @@ table = build_conditions_table(bool_conds, df, effectiveness, weights, n_groups=
 
 This produces a summary `DataFrame` where each condition is tagged by group along with the provided effectiveness and weight.
 
+## Tests
+
+Latest test run:
+
+```bash
+pytest -q
+```
+
+```
+41 passed
+```
+


### PR DESCRIPTION
## Summary
- Prevent feature index substitution collisions via `\bfeature_(\d+)\b` pattern
- Parse leaf values and classes robustly; expose `percentil` and `n_jobs` with safe parallel fallback
- Support scientific/underscore numbers and empty frames in `get_fro`
- Add tests for feature replacement, class leaves, percentile and parallel consistency
- Document test run in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896ef84a4cc832cad93b25b72efc1cf