### PR TITLE
Add detail toggle to InsideForest fit

### DIFF
--- a/InsideForest/inside_forest.py
+++ b/InsideForest/inside_forest.py
@@ -38,6 +38,9 @@ class _BaseInsideForest:
     divide : int, default 5
         Value forwarded to :func:`get_frontiers` when computing cluster
         frontiers.
+    get_detail : bool, default False
+        When ``True`` :meth:`fit` computes and stores additional cluster
+        details and frontiers.
     """
 
     def __init__(
@@ -50,6 +53,7 @@ class _BaseInsideForest:
         include_summary_cluster=False,
         balanced=False,
         divide=5,
+        get_detail=False,
     ):
         self.rf_params = rf_params or {}
         self.tree_params = tree_params or {}
@@ -58,6 +62,7 @@ class _BaseInsideForest:
         self.include_summary_cluster = include_summary_cluster
         self.balanced = balanced
         self.divide = divide
+        self.get_detail = get_detail
 
         self.rf = rf_cls(**self.rf_params)
         self.trees = Trees(**self.tree_params)
@@ -94,6 +99,7 @@ class _BaseInsideForest:
             "include_summary_cluster": self.include_summary_cluster,
             "balanced": self.balanced,
             "divide": self.divide,
+            "get_detail": self.get_detail,
         }
 
     def set_params(self, **params):
@@ -132,6 +138,7 @@ class _BaseInsideForest:
                 "include_summary_cluster",
                 "balanced",
                 "divide",
+                "get_detail",
             }:
                 setattr(self, key, value)
             else:
@@ -139,8 +146,11 @@ class _BaseInsideForest:
 
         return self
 
-    def fit(self, X, y=None, rf=None, get_detail=False):
+    def fit(self, X, y=None, rf=None):
         """Fit the internal random forest and compute cluster labels.
+
+        Whether detailed cluster information is computed depends on the
+        ``get_detail`` attribute set during initialization.
 
         Parameters
         ----------
@@ -154,10 +164,6 @@ class _BaseInsideForest:
             the estimator created during initialization is used. If the
             provided estimator is already trained, it will be used as is
             without additional fitting.
-        get_detail : bool, default False
-            When ``True`` additional attributes describing the clusters are
-            computed and stored. If ``False`` the fitting process stops after
-            obtaining :attr:`labels_`.
 
         Raises
         ------
@@ -210,7 +216,7 @@ class _BaseInsideForest:
         )
         df_reres = self.regions.prio_ranges(separacion_dim=separacion_dim, df=df)
 
-        if get_detail:
+        if self.get_detail:
             df_datos_clusterizados, df_clusters_descripcion, labels = self.regions.labels(
                 df=df,
                 df_reres=df_reres,
@@ -396,6 +402,7 @@ class _BaseInsideForest:
             "include_summary_cluster": self.include_summary_cluster,
             "balanced": self.balanced,
             "divide": self.divide,
+            "get_detail": self.get_detail,
             "labels_": self.labels_,
             "feature_names_": self.feature_names_,
             "df_clusters_descript_": self.df_clusters_descript_,
@@ -429,6 +436,7 @@ class _BaseInsideForest:
             include_summary_cluster=payload["include_summary_cluster"],
             balanced=payload["balanced"],
             divide=payload["divide"],
+            get_detail=payload.get("get_detail", False),
         )
         model.rf = payload["rf"]
         model.labels_ = payload["labels_"]
@@ -453,6 +461,7 @@ class InsideForestClassifier(_BaseInsideForest):
         include_summary_cluster=False,
         balanced=False,
         divide=5,
+        get_detail=False,
     ):
         super().__init__(
             RandomForestClassifier,
@@ -463,6 +472,7 @@ class InsideForestClassifier(_BaseInsideForest):
             include_summary_cluster=include_summary_cluster,
             balanced=balanced,
             divide=divide,
+            get_detail=get_detail,
         )
 
 
@@ -479,6 +489,7 @@ class InsideForestRegressor(_BaseInsideForest):
         include_summary_cluster=False,
         balanced=False,
         divide=5,
+        get_detail=False,
     ):
         super().__init__(
             RandomForestRegressor,
@@ -489,6 +500,7 @@ class InsideForestRegressor(_BaseInsideForest):
             include_summary_cluster=include_summary_cluster,
             balanced=balanced,
             divide=divide,
+            get_detail=get_detail,
         )
 
 

--- a/InsideForest/regions.py
+++ b/InsideForest/regions.py
@@ -1705,7 +1705,8 @@ class Regions:
 
   def labels(self, df, df_reres, n_clusters = None,
              include_summary_cluster=False,
-             balanced=False):
+             balanced=False,
+             return_dfs=True):
     """Assign cluster labels by selecting and applying rules.
 
     Parameters
@@ -1722,14 +1723,15 @@ class Regions:
     balanced : bool, default False
         Use balanced assignment of cluster labels instead of probability based
         assignment.
+    return_dfs : bool, default True
+        When ``True`` return both the clustered DataFrame and the cluster
+        description. If ``False`` only the computed labels are returned.
 
     Returns
     -------
-    tuple[pd.DataFrame, pd.DataFrame]
-        A tuple ``(df_datos_clusterizados, df_clusters_descripcion)`` where the
-        first element contains the original data with an added ``cluster``
-        column and the second describes each cluster's effectiveness and
-        support metrics.
+    If ``return_dfs`` is True a tuple ``(df_datos_clusterizados,
+    df_clusters_descripcion, labels)`` is returned. Otherwise only ``labels``
+    is produced.
     """
     
     lista_reglas = copy.deepcopy(df_reres)
@@ -1766,13 +1768,15 @@ class Regions:
       labels = self.max_prob_clusters(records=records, probs=probas, 
                                       n_clusters=n_clusters, seed=1)
     
-    if not include_summary_cluster:
-       rem_cols = ['n_clusters','ponderadores_list','ponderador_mean']
-       df_datos_clusterizados = df_datos_clusterizados.drop(columns=rem_cols)
-    
-    df_datos_clusterizados['cluster'] = labels
+    if return_dfs:
+       if not include_summary_cluster:
+          rem_cols = ['n_clusters','ponderadores_list','ponderador_mean']
+          df_datos_clusterizados = df_datos_clusterizados.drop(columns=rem_cols)
 
-    return df_datos_clusterizados, df_clusters_descripcion
+       df_datos_clusterizados['cluster'] = labels
+       return df_datos_clusterizados, df_clusters_descripcion, labels
+    else:
+       return labels
 
   
   def get_corr_clust(self, df_datos_clusterizados):

--- a/tests/test_inside_forest_fit_predict.py
+++ b/tests/test_inside_forest_fit_predict.py
@@ -162,3 +162,17 @@ def test_score_matches_rf_and_normalizes_input():
     X_norm.columns = [c.replace(" ", "_") for c in X_norm.columns]
     expected = model.rf.score(X_norm, y)
     assert model.score(X_messy, y) == expected
+
+
+def test_fit_respects_get_detail_flag():
+    X = pd.DataFrame(data={'feat1': [0, 1, 2, 3], 'feat2': [3, 2, 1, 0]})
+    y = [0, 1, 0, 1]
+    model = InsideForestClassifier(rf_params={'n_estimators': 5, 'random_state': 0})
+    model.fit(X=X, y=y)
+    assert model.df_clusters_descript_ is None
+
+    model_detail = InsideForestClassifier(
+        rf_params={'n_estimators': 5, 'random_state': 0}, get_detail=True
+    )
+    model_detail.fit(X=X, y=y)
+    assert model_detail.df_clusters_descript_ is not None

--- a/tests/test_inside_forest_params.py
+++ b/tests/test_inside_forest_params.py
@@ -14,6 +14,7 @@ def test_get_params_returns_init_values():
         include_summary_cluster=True,
         balanced=True,
         divide=3,
+        get_detail=True,
     )
     params = model.get_params()
     assert params["rf_params"]["n_estimators"] == 5
@@ -22,6 +23,7 @@ def test_get_params_returns_init_values():
     assert params["include_summary_cluster"] is True
     assert params["balanced"] is True
     assert params["divide"] == 3
+    assert params["get_detail"] is True
 
 
 def test_set_params_updates_attributes():
@@ -36,6 +38,9 @@ def test_set_params_updates_attributes():
 
     model.set_params(n_clusters=7)
     assert model.n_clusters == 7
+
+    model.set_params(get_detail=True)
+    assert model.get_detail is True
 
     with pytest.raises(ValueError):
         model.set_params(unknown=1)

--- a/tests/test_inside_forest_regressor_fit_predict.py
+++ b/tests/test_inside_forest_regressor_fit_predict.py
@@ -165,3 +165,17 @@ def test_score_matches_rf_and_normalizes_input():
     expected = model.rf.score(X_norm, y)
     assert model.score(X_messy, y) == pytest.approx(expected)
 
+
+def test_fit_respects_get_detail_flag_regressor():
+    X = pd.DataFrame(data={'feat1': [0, 1, 2, 3], 'feat2': [3, 2, 1, 0]})
+    y = [0.1, 0.4, 0.2, 0.3]
+    model = InsideForestRegressor(rf_params={'n_estimators': 5, 'random_state': 0})
+    model.fit(X=X, y=y)
+    assert model.df_clusters_descript_ is None
+
+    model_detail = InsideForestRegressor(
+        rf_params={'n_estimators': 5, 'random_state': 0}, get_detail=True
+    )
+    model_detail.fit(X=X, y=y)
+    assert model_detail.df_clusters_descript_ is not None
+


### PR DESCRIPTION
## Summary
- allow `InsideForest.fit` to skip detailed cluster calculations via new `get_detail` flag
- support returning just labels from region extraction
- streamline `predict` to use direct labels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689768ce51c0832caa70eb5fcb7274b5