### PR TITLE
Refactor cluster selector utilities

### DIFF
--- a/InsideForest/__init__.py
+++ b/InsideForest/__init__.py
@@ -16,6 +16,7 @@ from .cluster_selector import (
     MenuClusterSelector,
     balance_lists_n_clusters,
     max_prob_clusters,
+    SAConfig,
 )
 
 # Backward compatibility

--- a/InsideForest/regions.py
+++ b/InsideForest/regions.py
@@ -20,7 +20,7 @@ import math
 from scipy.spatial.distance import squareform
 from scipy.cluster.hierarchy import linkage, fcluster
 import logging
-from .cluster_selector import balance_lists_n_clusters, max_prob_clusters
+from .cluster_selector import balance_lists_n_clusters, max_prob_clusters, SAConfig
 
 logger = logging.getLogger(__name__)
 
@@ -1649,12 +1649,13 @@ class Regions:
     df_clusters_descripcion['cluster_ef_sample'] = abs(df_clusters_descripcion['cluster_ef_sample'])
 
     # Tratamiento de los clusters para agregar n_cluster
+    cfg = SAConfig(seed=1)
     if balanced:
       labels = balance_lists_n_clusters(records=records,
-                                        n_clusters=n_clusters, seed=1)
+                                        n_clusters=n_clusters, config=cfg)
     else:
       labels = max_prob_clusters(records=records, probs=probas,
-                                 n_clusters=n_clusters, seed=1)
+                                 n_clusters=n_clusters, config=cfg)
     
     if return_dfs:
        if not include_summary_cluster:


### PR DESCRIPTION
## Summary
- Pull shared helper logic out to private functions
- Add SAConfig object for simulated annealing hyperparameters and seed
- Use greedy initialization helper and configuration in regions helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689783edd950832ca6f179d0f3013c70