### PR TITLE
Allow selecting cluster selection method

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -115,6 +115,14 @@ pred_labels = in_f.predict(X_rest)  # etiquetas de cluster para los datos restan
 etiquetas_entrenamiento = in_f.labels_  # etiquetas para el subconjunto de entrenamiento
 ```
 
+Puedes controlar cómo se eligen las etiquetas finales mediante el parámetro
+`method`. Las estrategias disponibles son:
+
+- `"select_clusters"`: selección directa basada en reglas (por defecto)
+- `"balance_lists_n_clusters"`: balancea el número de asignaciones por clúster
+- `"max_prob_clusters"`: prioriza los clústers con mayor probabilidad
+- `"menu"`: aplica `MenuClusterSelector` para maximizar un objetivo informativo global
+
 Después del ajuste, puedes consultar las importancias de las variables del
 bosque aleatorio y visualizarlas opcionalmente:
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ pred_labels = in_f.predict(X_rest)  # cluster labels for the remaining data
 training_labels = in_f.labels_  # labels for the training subset
 ```
 
+You can control how final cluster labels are consolidated through the
+`method` parameter. Available strategies are:
+
+- `"select_clusters"`: direct rule-based selection (default)
+- `"balance_lists_n_clusters"`: balance cluster assignments
+- `"max_prob_clusters"`: favor clusters with higher probabilities
+- `"menu"`: apply `MenuClusterSelector` to maximize an information-theoretic objective
+
 After fitting, you can inspect the random forest's feature importances and
 optionally visualize them:
 

--- a/tests/test_inside_forest_fit_predict.py
+++ b/tests/test_inside_forest_fit_predict.py
@@ -68,15 +68,33 @@ def test_custom_label_and_frontier_params():
         rf_params={'n_estimators': 5, 'random_state': 0},
         n_clusters=2,
         include_summary_cluster=True,
-        balanced=True,
+        method="balance_lists_n_clusters",
         divide=3,
     )
     model.fit(X=df)
     assert model.n_clusters == 2
     assert model.include_summary_cluster is True
-    assert model.balanced is True
+    assert model.method == "balance_lists_n_clusters"
     assert model.divide == 3
     assert model.labels_.shape[0] == len(df)
+
+
+def test_menu_cluster_selector_runs():
+    df = pd.DataFrame(
+        data={
+            'feat1': [0, 1, 2, 3],
+            'feat2': [3, 2, 1, 0],
+            'target': [0, 1, 0, 1],
+        }
+    )
+    model = InsideForestClassifier(
+        rf_params={'n_estimators': 5, 'random_state': 0},
+        n_clusters=2,
+        method="menu",
+    )
+    model.fit(X=df)
+    preds = model.predict(X=df[['feat1', 'feat2']])
+    assert preds.shape == (4,)
 
 
 def test_fit_accepts_custom_rf_instance():

--- a/tests/test_inside_forest_params.py
+++ b/tests/test_inside_forest_params.py
@@ -12,7 +12,7 @@ def test_get_params_returns_init_values():
         tree_params={"lang": "python"},
         n_clusters=2,
         include_summary_cluster=True,
-        balanced=True,
+        method="balance_lists_n_clusters",
         divide=3,
         get_detail=True,
     )
@@ -21,7 +21,7 @@ def test_get_params_returns_init_values():
     assert params["tree_params"]["lang"] == "python"
     assert params["n_clusters"] == 2
     assert params["include_summary_cluster"] is True
-    assert params["balanced"] is True
+    assert params["method"] == "balance_lists_n_clusters"
     assert params["divide"] == 3
     assert params["get_detail"] is True
 
@@ -41,6 +41,12 @@ def test_set_params_updates_attributes():
 
     model.set_params(get_detail=True)
     assert model.get_detail is True
+
+    model.set_params(method="max_prob_clusters")
+    assert model.method == "max_prob_clusters"
+
+    model.set_params(method="menu")
+    assert model.method == "menu"
 
     with pytest.raises(ValueError):
         model.set_params(unknown=1)

--- a/tests/test_inside_forest_regressor_fit_predict.py
+++ b/tests/test_inside_forest_regressor_fit_predict.py
@@ -70,13 +70,13 @@ def test_custom_label_and_frontier_params():
         rf_params={"n_estimators": 5, "random_state": 0},
         n_clusters=2,
         include_summary_cluster=True,
-        balanced=True,
+        method="balance_lists_n_clusters",
         divide=3,
     )
     model.fit(X=df)
     assert model.n_clusters == 2
     assert model.include_summary_cluster is True
-    assert model.balanced is True
+    assert model.method == "balance_lists_n_clusters"
     assert model.divide == 3
     assert model.labels_.shape[0] == len(df)
 


### PR DESCRIPTION
## Summary
- expose MenuClusterSelector as an additional `method` option
- document available cluster selection strategies in both READMEs and persist MenuClusterSelector in saved models
- add tests exercising the new method

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68978a9e2714832cba2785fa94c72408