### PR TITLE
Handle full tree coverage and cluster list uniqueness

### DIFF
--- a/InsideForest/regions.py
+++ b/InsideForest/regions.py
@@ -1111,11 +1111,23 @@ class Regions:
       df_datos_clusterizados['cluster'] = clusters_datos  # Cluster final (mayor ponderador)
 
       if keep_all_clusters:
-          df_datos_clusterizados['n_clusters'] = [len(lst) for lst in clusters_datos_all]
-          df_datos_clusterizados['clusters_list'] = clusters_datos_all
-          df_datos_clusterizados['ponderadores_list'] = ponderadores_datos_all
+          # Remove duplicate cluster assignments while keeping the highest
+          # weight for each cluster
+          uniq_clusters = []
+          uniq_weights = []
+          for cls_list, w_list in zip(clusters_datos_all, ponderadores_datos_all):
+              seen = {}
+              for c, w in zip(cls_list, w_list):
+                  if c not in seen or w > seen[c]:
+                      seen[c] = w
+              uniq_clusters.append(list(seen.keys()))
+              uniq_weights.append(list(seen.values()))
+
+          df_datos_clusterizados['clusters_list'] = uniq_clusters
+          df_datos_clusterizados['ponderadores_list'] = uniq_weights
+          df_datos_clusterizados['n_clusters'] = [len(lst) for lst in uniq_clusters]
           df_datos_clusterizados['ponderador_mean'] = [
-              np.mean(lst) if lst else np.nan for lst in ponderadores_datos_all
+              np.mean(lst) if lst else np.nan for lst in uniq_weights
           ]
 
       # --- 4) Generar la descripción de clusters (usando el método propio)

--- a/InsideForest/trees.py
+++ b/InsideForest/trees.py
@@ -511,7 +511,13 @@ class Trees:
        logger.info("Obtaining a summary of the trees")
     
     try:
-       df_summ = self.get_summary_optimizado(df, df_full_arboles, var_obj, no_trees_search, verbose)
+       df_summ = self.get_summary_optimizado(
+           df,
+           df_full_arboles,
+           var_obj,
+           no_branch_lim=no_trees_search,
+           verbose=verbose,
+       )
     except Exception as exc:
        logger.exception("Error generating tree summary: %s", exc)
        raise

--- a/InsideForest/trees.py
+++ b/InsideForest/trees.py
@@ -276,8 +276,15 @@ class Trees:
     return agrupacion
 
   def get_summary_optimizado(self, data1, df_full_arboles, var_obj,
-                              no_branch_lim=500, verbose=0, n_jobs=1):
-      """Resume las reglas evaluando las condiciones de manera vectorizada."""
+                              no_branch_lim=None, verbose=0, n_jobs=1):
+      """Resume las reglas evaluando las condiciones de manera vectorizada.
+
+      Parameters
+      ----------
+      no_branch_lim : int | None, optional
+          Número máximo de árboles a procesar. Si es ``None`` se utilizan
+          todos los árboles disponibles.
+      """
 
       # 1) Calcular el pivot que resume por N_regla, N_arbol, feature, operador
       agrupacion = pd.pivot_table(
@@ -297,7 +304,9 @@ class Trees:
       agrupacion = pd.concat([agrupacion_min, agrupacion_max]).sort_values(['N_arbol', 'N_regla'])
 
       # 4) Seleccionar los árboles a procesar
-      top_100_arboles = agrupacion['N_arbol'].unique()[:no_branch_lim]
+      top_100_arboles = agrupacion['N_arbol'].unique()
+      if no_branch_lim is not None:
+          top_100_arboles = top_100_arboles[:no_branch_lim]
 
       # Convertir datos a matriz NumPy y preparar mapeo de columnas
       X = data1.to_numpy()
@@ -447,7 +456,7 @@ class Trees:
     separacion_dim = self.get_dfs_dim(rectangles_)
     return separacion_dim
 
-  def get_branches(self, df, var_obj, regr, no_trees_search=500, verbose=0):
+  def get_branches(self, df, var_obj, regr, no_trees_search=None, verbose=0):
     """Extract rectangular rules from a tree ensemble.
 
     Parameters
@@ -459,8 +468,9 @@ class Trees:
     regr : object
         Trained estimator supporting ``estimators_`` (scikit-learn) or
         ``toDebugString`` (PySpark) interfaces.
-    no_trees_search : int, default 500
+    no_trees_search : int | None, optional
         Maximum number of trees to analyse when summarising the forest.
+        If ``None`` all trees are used.
     verbose : int, default 0
         Verbosity level; ``1`` enables progress bars and logging.
 


### PR DESCRIPTION
## Summary
- Process all trees in summary extraction when limits aren't specified
- Deduplicate cluster assignments to keep highest-weight unique clusters

## Testing
- `pytest tests/test_descrip.py tests/test_descrip_helpers.py tests/test_eps_search_perf.py tests/test_inside_forest_regressor_fit_predict.py tests/test_inside_forest_params.py tests/test_iou_equivalence.py tests/test_trees.py`
- `pytest tests/test_inside_forest_fit_predict.py::test_menu_cluster_selector_runs` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6897c8bdd7fc832c98bb90aa7150e146