### PR TITLE
Handle fallback cluster assignment in select_clusters

### DIFF
--- a/tests/test_cluster_selector.py
+++ b/tests/test_cluster_selector.py
@@ -1,0 +1,25 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pandas as pd
+from InsideForest.cluster_selector import select_clusters
+
+
+def test_fallback_cluster_assignment():
+    df_datos = pd.DataFrame({'x': [0.5, 2.0]})
+    cols = pd.MultiIndex.from_tuples([
+        ('linf', 'x'),
+        ('lsup', 'x'),
+        ('metrics', 'ponderador'),
+    ])
+    df_reglas = pd.DataFrame([[0.0, 1.0, 1.0]], columns=cols)
+    df_reglas['cluster'] = [1.0]
+
+    clusters, clusters_all, ponderadores_all = select_clusters(
+        df_datos, df_reglas, keep_all_clusters=True, fallback_cluster=99
+    )
+
+    assert clusters[0] == 1.0
+    assert clusters[1] == 99
+    assert clusters_all[1] == [99]
+    assert ponderadores_all[1] == [0.0]


### PR DESCRIPTION
## Summary
- add optional `fallback_cluster` parameter to select_clusters to handle unmatched records
- warn about unassigned rows or assign a fallback cluster and append it to all cluster lists
- add unit test covering fallback assignment

## Testing
- `pytest -q`
- `pytest tests/test_cluster_selector.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689824943214832ca2b0fde5eefdc894