### PR TITLE
Ensure get_knn_rows returns DataFrame pair and add tests

### DIFF
--- a/InsideForest/models.py
+++ b/InsideForest/models.py
@@ -44,7 +44,9 @@ class Models:
 
     X = df.drop(columns=[target_col]).values
     y = df.loc[:, target_col].values
-    for k in range(1,int(len(df))):
+    fp = fn = 0
+    y_pred = None
+    for k in range(1, int(len(df))):
       try:
         knn = KNeighborsClassifier(n_neighbors=k)
         knn.fit(X, y)
@@ -55,17 +57,20 @@ class Models:
         break
       tn, fp, fn, tp = cm.ravel()
       if criterio_fp:
-        if fp>min_obs:
+        if fp > min_obs:
           break
       else:
-        if fn>min_obs:
+        if fn > min_obs:
           break
-    if fn>0:
+    if y_pred is None:
+      return df.iloc[0:0], df
+    if fn > 0:
       false_negatives = (y == 1) & (y_pred == 0)
       return df[false_negatives], df[~false_negatives]
-    if fp>0:
+    if fp > 0:
       false_positives = (y == 0) & (y_pred == 1)
       return df[false_positives], df[~false_positives]
+    return df.iloc[0:0], df
   
   def get_cvRF(self, X_train, y_train, param_grid):
     """Grid-search a RandomForest classifier.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,30 @@
+import pandas as pd
+from InsideForest.models import Models
+
+
+def test_get_knn_rows_success():
+    df = pd.DataFrame({'feature': [0, 1, 2, 3, 4, 5],
+                       'target': [0, 0, 0, 1, 1, 1]})
+    models = Models()
+    mis_df, rest_df = models.get_knn_rows(df, 'target', criterio_fp=False, min_obs=0)
+    assert not mis_df.empty
+    assert len(mis_df) + len(rest_df) == len(df)
+    assert rest_df.equals(df.drop(mis_df.index))
+
+
+def test_get_knn_rows_no_misclassification():
+    df = pd.DataFrame({'feature': [0, 1, 2, 3, 4, 5],
+                       'target': [0, 0, 0, 1, 1, 1]})
+    models = Models()
+    mis_df, rest_df = models.get_knn_rows(df, 'target', min_obs=10)
+    assert mis_df.empty
+    assert rest_df.equals(df)
+
+
+def test_get_knn_rows_training_error():
+    df = pd.DataFrame({'feature': ['a', 'b', 'c'],
+                       'target': [0, 1, 0]})
+    models = Models()
+    mis_df, rest_df = models.get_knn_rows(df, 'target')
+    assert mis_df.empty
+    assert rest_df.equals(df)


### PR DESCRIPTION
## Summary
- Initialize `fp`, `fn`, and `y_pred` before the KNN loop
- Guarantee `get_knn_rows` always returns two DataFrames, even on errors or perfect classification
- Add tests for normal, error, and no-misclassification scenarios

## Testing
- `python -m pytest tests/test_models.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b95a5c584832ca66196f9c871d5f2