### PR TITLE
Handle missing variables in cluster selector rules

### DIFF
--- a/InsideForest/cluster_selector.py
+++ b/InsideForest/cluster_selector.py
@@ -86,6 +86,9 @@ def select_clusters(
         ponderador = regla['ponderador']
         cluster = regla['cluster']
 
+        missing_cols = [col for col in variables if col not in df_datos.columns]
+        if missing_cols:
+            raise KeyError(f"Columns not found in df_datos: {missing_cols}")
         X_datos = df_datos[variables]
         condiciones = [
             (X_datos[var].to_numpy() >= linf[var]) & (X_datos[var].to_numpy() <= lsup[var])

--- a/tests/test_cluster_selector.py
+++ b/tests/test_cluster_selector.py
@@ -2,6 +2,7 @@ import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import pandas as pd
+import pytest
 from InsideForest.cluster_selector import select_clusters
 
 
@@ -23,3 +24,18 @@ def test_fallback_cluster_assignment():
     assert clusters[1] == 99
     assert clusters_all[1] == [99]
     assert ponderadores_all[1] == [0.0]
+
+
+def test_missing_column_in_rule_raises_error():
+    df_datos = pd.DataFrame({'x': [0.5]})
+    cols = pd.MultiIndex.from_tuples([
+        ('linf', 'y'),
+        ('lsup', 'y'),
+        ('metrics', 'ponderador'),
+    ])
+    df_reglas = pd.DataFrame([[0.0, 1.0, 1.0]], columns=cols)
+    df_reglas['cluster'] = [1.0]
+
+    with pytest.raises(KeyError) as excinfo:
+        select_clusters(df_datos, df_reglas)
+    assert 'y' in str(excinfo.value)


### PR DESCRIPTION
## Summary
- validate that all variables referenced by a rule exist in the dataset
- raise a clear KeyError when rule variables are missing
- add regression test for rules referencing absent columns

## Testing
- `pytest -q`
- `pytest tests/test_cluster_selector.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b9596a49c832c970c68fad8571f85