### PR TITLE
Handle empty variable list in branch extraction

### DIFF
--- a/InsideForest/labels.py
+++ b/InsideForest/labels.py
@@ -129,6 +129,12 @@ class Labels:
         upper_bounds = sub_df.loc[row_index, 'lsup'].copy()
         variables = list(upper_bounds.index)
 
+        # Early exit when there are no variables to filter on.
+        # Returning an empty DataFrame prevents index errors when constructing
+        # boolean conditions on an empty list of variables.
+        if len(variables) == 0:
+            return df.iloc[0:0]
+
         conditions = [
             (df[var] <= upper_bounds[var]) & (df[var] > lower_bounds[var])
             for var in variables

--- a/tests/test_descrip_helpers.py
+++ b/tests/test_descrip_helpers.py
@@ -9,6 +9,7 @@ from InsideForest.descrip import (
     _scale_clusters,
     _compute_inflection_points,
     _merge_outputs,
+    _list_rules_to_text,
 )
 
 
@@ -87,3 +88,8 @@ def test_merge_outputs():
     }
     assert expected_cols.issubset(final_df.columns)
     assert "cluster_ponderador" not in final_df.columns
+
+
+def test_list_rules_to_text_empty_rule_set_returns_placeholder():
+    meta_df = pd.DataFrame()
+    assert _list_rules_to_text([], meta_df, lang="en") == "—"


### PR DESCRIPTION
## Summary
- Guard against empty variable lists in `Labels.get_branch` by returning an empty DataFrame
- Add regression test ensuring `_list_rules_to_text` returns placeholder for empty rule sets

## Testing
- `pytest tests/test_descrip_helpers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b959d3970832cafa0cc493b5a7650