### PR TITLE
Exclude target column when y provided

### DIFF
--- a/InsideForest/inside_forest.py
+++ b/InsideForest/inside_forest.py
@@ -220,6 +220,8 @@ class _BaseInsideForest:
         else:
             if isinstance(X, pd.DataFrame):
                 X_df = X.copy()
+                if self.var_obj in X_df.columns:
+                    X_df = X_df.drop(columns=[self.var_obj])
             else:
                 X_df = pd.DataFrame(data=X)
 

--- a/tests/test_inside_forest_fit_predict.py
+++ b/tests/test_inside_forest_fit_predict.py
@@ -49,6 +49,22 @@ def test_fit_accepts_df_with_target_column():
     assert model.labels_.shape[0] == len(df)
 
 
+def test_fit_with_y_and_df_includes_target_column():
+    df = pd.DataFrame(
+        data={
+            'feat1': [0, 1, 2, 3],
+            'feat2': [3, 2, 1, 0],
+            'target': [0, 1, 0, 1],
+        }
+    )
+    y = df['target'].to_numpy()
+    model = InsideForestClassifier(rf_params={'n_estimators': 5, 'random_state': 0})
+    model.fit(X=df, y=y)
+    assert 'target' not in model.feature_names_
+    preds = model.predict(df[['feat1', 'feat2']])
+    assert preds.shape == (4,)
+
+
 def test_fit_df_missing_target_raises():
     df = pd.DataFrame(data={'feat1': [0, 1], 'feat2': [1, 0]})
     model = InsideForestClassifier()


### PR DESCRIPTION
## Summary
- Ensure `_BaseInsideForest.fit` drops `var_obj` from feature DataFrames when `y` is supplied separately
- Add regression test for fitting with `y` and a DataFrame containing the target column

## Testing
- `pytest tests/test_inside_forest_fit_predict.py::test_fit_with_y_and_df_includes_target_column -q`
- `pytest tests/test_inside_forest_fit_predict.py::test_fit_accepts_df_with_target_column -q`


------
https://chatgpt.com/codex/tasks/task_e_689b958f7370832c8a334fb52933265a