### PR TITLE
docs: add OpenAI usage examples

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -252,6 +252,29 @@ os.environ["OPENAI_API_KEY"] = "sk-your-key"
 res = generate_descriptions(iris_conds, OPENAI_API_KEY=os.getenv("OPENAI_API_KEY"))
 ```
 
+También puedes interactuar directamente con la API de OpenAI:
+
+```python
+from openai import OpenAI
+import os
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+respuesta = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[
+        {"role": "system", "content": "Eres un asistente útil."},
+        {
+            "role": "user",
+            "content": (
+                "Resume: 4.3 <= sepal length (cm) <= 5.8 y "
+                "1.0 <= petal width (cm) <= 1.8"
+            ),
+        },
+    ],
+)
+print(respuesta.choices[0].message.content)
+```
+
 ### `categorize_conditions`
 
 ```python

--- a/README.md
+++ b/README.md
@@ -254,6 +254,29 @@ os.environ["OPENAI_API_KEY"] = "sk-your-key"
 res = generate_descriptions(iris_conds, OPENAI_API_KEY=os.getenv("OPENAI_API_KEY"))
 ```
 
+You can also interact with the OpenAI API directly:
+
+```python
+from openai import OpenAI
+import os
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {
+            "role": "user",
+            "content": (
+                "Summarize: 4.3 <= sepal length (cm) <= 5.8 and "
+                "1.0 <= petal width (cm) <= 1.8"
+            ),
+        },
+    ],
+)
+print(response.choices[0].message.content)
+```
+
 ### `categorize_conditions`
 
 ```python

--- a/README.paper.md
+++ b/README.paper.md
@@ -282,6 +282,20 @@ La organización del código refleja el proceso anterior en módulos especializa
 - `Models` proporciona utilidades de validación cruzada y métodos vecinos más cercanos.
 - `Descrip` genera descripciones en lenguaje natural, generaliza condiciones y construye tablas de interpretación.
 
+Ejemplo de integración con OpenAI para `Descrip`:
+
+```python
+from openai import OpenAI
+import os
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+respuesta = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Describe la región: 4.3 <= sepal length (cm) <= 5.8"}],
+)
+print(respuesta.choices[0].message.content)
+```
+
 ## 4. Metodología de uso
 El método central `InsideForest.fit(X, y)` ejecuta una secuencia determinista de pasos que convierte un `RandomForest` en regiones interpretables y etiquetas de cluster. El flujo puede resumirse como:
 


### PR DESCRIPTION
## Summary
- add example code to call the OpenAI API in English and Spanish READMEs
- document OpenAI integration example in the technical paper README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a25b489440832c9f4031b7a215e26c