### PR TITLE
Add FAST configuration and feature reduction options

### DIFF
--- a/InsideForest/inside_forest.py
+++ b/InsideForest/inside_forest.py
@@ -1,12 +1,91 @@
-import pandas as pd
+from typing import Optional, Dict, Any, List, Tuple
+
+import numpy as np
 import joblib
+try:
+    import pandas as pd
+    _HAS_PANDAS = True
+except Exception:
+    _HAS_PANDAS = False
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.validation import check_is_fitted
+from sklearn.feature_selection import SelectKBest, mutual_info_classif, mutual_info_regression
+from sklearn.utils.multiclass import type_of_target
 
 from .trees import Trees
 from .regions import Regions
 from .descrip import get_frontiers
+
+
+# ---------- FAST helpers ----------
+def _size_bucket(n: int, d: int) -> str:
+    prod = n * d
+    if prod <= 50_000:
+        return "small"
+    elif prod <= 200_000:
+        return "medium"
+    elif prod <= 1_000_000:
+        return "large"
+    else:
+        return "huge"
+
+
+def _choose_k_features(n: int, d: int) -> int:
+    bucket = _size_bucket(n, d)
+    if bucket == "small":
+        k = min(d, 64)
+    elif bucket == "medium":
+        k = min(d, 48)
+    elif bucket == "large":
+        k = min(d, 32)
+    else:
+        k = min(d, 24)
+    return max(8, k)
+
+
+def _choose_fast_params(n: int, d: int) -> Dict[str, Any]:
+    bucket = _size_bucket(n, d)
+    if bucket == "small":
+        rf_params = dict(n_estimators=80, max_depth=12, min_samples_leaf=3, n_jobs=-1, random_state=42)
+        tree_params = dict(percentil=98, low_frac=0.02)
+        divide = 3
+        method = "menu"
+    elif bucket == "medium":
+        rf_params = dict(n_estimators=60, max_depth=10, min_samples_leaf=5, n_jobs=-1, random_state=42)
+        tree_params = dict(percentil=99, low_frac=0.01)
+        divide = 3
+        method = "menu"
+    elif bucket == "large":
+        rf_params = dict(n_estimators=40, max_depth=9, min_samples_leaf=8, n_jobs=-1, random_state=42)
+        tree_params = dict(percentil=99.5, low_frac=0.0075)
+        divide = 3
+        method = "menu"
+    else:
+        rf_params = dict(n_estimators=30, max_depth=8, min_samples_leaf=10, n_jobs=-1, random_state=42)
+        tree_params = dict(percentil=99.7, low_frac=0.005)
+        divide = 3
+        method = "menu"
+
+    return dict(
+        rf_params=rf_params,
+        tree_params=tree_params,
+        divide=divide,
+        method=method,
+        get_detail=False,
+    )
+
+
+def _merge_dicts(base: Dict[str, Any], override: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not override:
+        return base
+    out = dict(base)
+    for k, v in override.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = {**out[k], **v}
+        else:
+            out[k] = v
+    return out
 
 
 class _BaseInsideForest:
@@ -67,7 +146,12 @@ class _BaseInsideForest:
         get_detail=False,
         leaf_percentile=95,
         low_leaf_fraction=0.05,
+        auto_fast=False,
+        auto_feature_reduce=False,
+        explicit_k_features: Optional[int] = None,
+        fast_overrides: Optional[Dict[str, Any]] = None,
     ):
+        self.rf_cls = rf_cls
         self.rf_params = rf_params or {}
         self.tree_params = tree_params or {}
         self.var_obj = var_obj
@@ -78,6 +162,19 @@ class _BaseInsideForest:
         self.get_detail = get_detail
         self.leaf_percentile = leaf_percentile
         self.low_leaf_fraction = low_leaf_fraction
+
+        # FAST knobs
+        self.auto_fast = auto_fast
+        self.auto_feature_reduce = auto_feature_reduce
+        self.explicit_k_features = explicit_k_features
+        self.fast_overrides = fast_overrides or {}
+
+        # FAST bookkeeping
+        self._feature_mask_: Optional[np.ndarray] = None
+        self.feature_names_in_: Optional[List[str]] = None
+        self.feature_names_out_: Optional[List[str]] = None
+        self._size_bucket_: Optional[str] = None
+        self._fast_params_used_: Optional[Dict[str, Any]] = None
 
         # Ensure tree parameters include the percentile settings
         self.tree_params.setdefault("percentil", leaf_percentile)
@@ -121,6 +218,10 @@ class _BaseInsideForest:
             "get_detail": self.get_detail,
             "leaf_percentile": self.leaf_percentile,
             "low_leaf_fraction": self.low_leaf_fraction,
+            "auto_fast": self.auto_fast,
+            "auto_feature_reduce": self.auto_feature_reduce,
+            "explicit_k_features": self.explicit_k_features,
+            "fast_overrides": self.fast_overrides,
         }
 
     def set_params(self, **params):
@@ -164,6 +265,10 @@ class _BaseInsideForest:
                 "get_detail",
                 "leaf_percentile",
                 "low_leaf_fraction",
+                "auto_fast",
+                "auto_feature_reduce",
+                "explicit_k_features",
+                "fast_overrides",
             }:
                 setattr(self, key, value)
                 if key == "leaf_percentile":
@@ -176,6 +281,59 @@ class _BaseInsideForest:
                 raise ValueError(f"Invalid parameter '{key}'")
 
         return self
+
+    def _maybe_reduce_features(self, X, y=None):
+        """Optionally reduce features; preserve original column names if DataFrame."""
+        if not self.auto_feature_reduce:
+            if _HAS_PANDAS and isinstance(X, pd.DataFrame):
+                self.feature_names_in_ = list(X.columns)
+                self.feature_names_out_ = list(X.columns)
+            else:
+                self.feature_names_in_ = None
+                self.feature_names_out_ = None
+            self._feature_mask_ = None
+            return X
+
+        n, d = X.shape
+        k = (
+            self.explicit_k_features
+            if self.explicit_k_features is not None
+            else _choose_k_features(n, d)
+        )
+        k = min(k, d)
+
+        is_df = _HAS_PANDAS and isinstance(X, pd.DataFrame)
+        self.feature_names_in_ = list(X.columns) if is_df else None
+        X_arr = X.values if is_df else np.asarray(X)
+
+        support = None
+        if y is not None:
+            try:
+                ytype = type_of_target(y)
+            except Exception:
+                ytype = None
+            if ytype in {"binary", "multiclass"}:
+                sel = SelectKBest(mutual_info_classif, k=k).fit(X_arr, y)
+                support = sel.get_support()
+            elif ytype in {"continuous", "continuous-multioutput"}:
+                sel = SelectKBest(mutual_info_regression, k=k).fit(X_arr, y)
+                support = sel.get_support()
+        if support is None:
+            variances = X_arr.var(axis=0)
+            idx_sorted = np.argsort(-variances)[:k]
+            support = np.zeros(X_arr.shape[1], dtype=bool)
+            support[idx_sorted] = True
+
+        self._feature_mask_ = support
+
+        if is_df:
+            cols = np.array(self.feature_names_in_)
+            keep_cols = cols[support].tolist()
+            self.feature_names_out_ = keep_cols
+            return X[keep_cols]
+        else:
+            self.feature_names_out_ = None
+            return X_arr[:, support]
 
     def fit(self, X, y=None, rf=None):
         """Fit the internal random forest and compute cluster labels.
@@ -227,7 +385,45 @@ class _BaseInsideForest:
 
         # Replace spaces with underscores to keep compatibility with Trees
         X_df.columns = [str(c).replace(" ", "_") for c in X_df.columns]
+
+        # 0) Feature reduction (optional)
+        Xr = self._maybe_reduce_features(X_df, y)
+        if _HAS_PANDAS and isinstance(Xr, pd.DataFrame):
+            X_df = Xr
+        else:
+            X_df = pd.DataFrame(Xr)
         self.feature_names_ = list(X_df.columns)
+
+        # 1) Fast preset (optional)
+        if self.auto_fast:
+            n, d = X_df.shape
+            auto = _choose_fast_params(n, d)
+            combined = dict(auto)
+
+            if isinstance(self.rf_params, dict):
+                combined["rf_params"] = {**auto["rf_params"], **self.rf_params}
+            if isinstance(self.tree_params, dict):
+                combined["tree_params"] = {**auto["tree_params"], **self.tree_params}
+            if hasattr(self, "divide"):
+                combined["divide"] = getattr(self, "divide", auto["divide"])
+            if hasattr(self, "method"):
+                combined["method"] = "menu" if y is not None else getattr(self, "method", auto["method"])
+            if hasattr(self, "get_detail"):
+                combined["get_detail"] = getattr(self, "get_detail", auto["get_detail"])
+
+            combined = _merge_dicts(combined, self.fast_overrides)
+
+            self._fast_params_used_ = combined
+            self._size_bucket_ = _size_bucket(n, d)
+
+            self.rf_params = combined.get("rf_params", self.rf_params)
+            self.tree_params = combined.get("tree_params", self.tree_params)
+            self.divide = combined.get("divide", self.divide)
+            self.method = combined.get("method", self.method)
+            self.get_detail = combined.get("get_detail", self.get_detail)
+
+            self.rf = self.rf_cls(**self.rf_params)
+            self.trees = Trees(**self.tree_params)
 
         # Allow passing a custom random forest estimator
         if rf is not None:
@@ -520,6 +716,10 @@ class InsideForestClassifier(_BaseInsideForest):
         get_detail=False,
         leaf_percentile=95,
         low_leaf_fraction=0.05,
+        auto_fast=False,
+        auto_feature_reduce=False,
+        explicit_k_features: Optional[int] = None,
+        fast_overrides: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(
             RandomForestClassifier,
@@ -533,6 +733,10 @@ class InsideForestClassifier(_BaseInsideForest):
             get_detail=get_detail,
             leaf_percentile=leaf_percentile,
             low_leaf_fraction=low_leaf_fraction,
+            auto_fast=auto_fast,
+            auto_feature_reduce=auto_feature_reduce,
+            explicit_k_features=explicit_k_features,
+            fast_overrides=fast_overrides,
         )
 
 
@@ -552,6 +756,10 @@ class InsideForestRegressor(_BaseInsideForest):
         get_detail=False,
         leaf_percentile=95,
         low_leaf_fraction=0.05,
+        auto_fast=False,
+        auto_feature_reduce=False,
+        explicit_k_features: Optional[int] = None,
+        fast_overrides: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(
             RandomForestRegressor,
@@ -565,6 +773,10 @@ class InsideForestRegressor(_BaseInsideForest):
             get_detail=get_detail,
             leaf_percentile=leaf_percentile,
             low_leaf_fraction=low_leaf_fraction,
+            auto_fast=auto_fast,
+            auto_feature_reduce=auto_feature_reduce,
+            explicit_k_features=explicit_k_features,
+            fast_overrides=fast_overrides,
         )
 
 

--- a/README.es.md
+++ b/README.es.md
@@ -74,6 +74,22 @@ pred_labels = in_f.predict(X_rest)  # etiquetas de cluster para los datos restan
 etiquetas_entrenamiento = in_f.labels_  # etiquetas para el subconjunto de entrenamiento
 ```
 
+### Presets FAST y reducción de características
+
+InsideForest puede elegir automáticamente parámetros de entrenamiento más
+rápidos y reducir características según el tamaño del conjunto de datos:
+
+```python
+in_f = InsideForestClassifier(auto_fast=True, auto_feature_reduce=True)
+in_f.fit(X_train, y_train)
+```
+
+Usa `explicit_k_features` para fijar el número de características
+conservadas y `fast_overrides` para ajustar los presets automáticos.
+Tras el entrenamiento, los atributos `_feature_mask_`, `feature_names_in_`,
+`feature_names_out_`, `_size_bucket_` y `_fast_params_used_` muestran la
+configuración aplicada.
+
 Puedes controlar cómo se eligen las etiquetas finales mediante el parámetro
 `method`. Las estrategias disponibles son:
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ pred_labels = in_f.predict(X_rest)  # cluster labels for the remaining data
 training_labels = in_f.labels_  # labels for the training subset
 ```
 
+### FAST presets and feature reduction
+
+InsideForest can automatically pick faster training parameters and reduce
+features based on dataset size:
+
+```python
+in_f = InsideForestClassifier(auto_fast=True, auto_feature_reduce=True)
+in_f.fit(X_train, y_train)
+```
+
+Use `explicit_k_features` to fix the number of retained features and
+`fast_overrides` to tweak the automatic presets. After fitting, the
+attributes `_feature_mask_`, `feature_names_in_`, `feature_names_out_`,
+`_size_bucket_`, and `_fast_params_used_` reveal the applied settings.
+
 You can control how final cluster labels are consolidated through the
 `method` parameter. Available strategies are:
 


### PR DESCRIPTION
## Summary
- add optional FAST presets and automatic feature reduction knobs
- provide helper utilities for choosing presets and merging overrides
- integrate FAST config and feature reduction into `fit`
- document how to enable FAST presets and feature reduction in README
- remove unsupported FAST tree parameters

## Testing
- `pytest -q`  # 29 passed in 243.99s
- `pytest tests/test_inside_forest_params.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad3dc0f2b0832cbd922dfed17368da