### PR TITLE
Translate Spanish identifiers and docs

### DIFF
--- a/InsideForest/metadata.py
+++ b/InsideForest/metadata.py
@@ -33,7 +33,7 @@ class Profile(Enum):
 class MetaExtractor:
     """
     Extract a minimal, investigation or full slice of metadata for the
-    variables referenced in df_QW['cluster_descripcion'].
+    variables referenced in df_QW['cluster_description'].
 
     *Synonyms and suffix stripping are fully inferred from the metadata.*
     """
@@ -204,11 +204,11 @@ class MetaExtractor:
         cols: List[str] | None = None
     ) -> pd.DataFrame:
 
-        if "cluster_descripcion" not in df_QW.columns:
-            raise KeyError("df_QW must contain 'cluster_descripcion' column")
+        if "cluster_description" not in df_QW.columns:
+            raise KeyError("df_QW must contain 'cluster_description' column")
 
-        # tokens = self._tokens(df_QW["cluster_descripcion"])
-        tokens = self._extract_tokens(df_QW["cluster_descripcion"])
+        # tokens = self._tokens(df_QW["cluster_description"])
+        tokens = self._extract_tokens(df_QW["cluster_description"])
         mapping = {t: self._map_to_var(self._canon(t)) for t in tokens}
         valid   = {tok: var for tok, var in mapping.items() if var in list(self.meta.index)}
 
@@ -308,7 +308,7 @@ def experiments_from_df2(
     Parameters
     ----------
     df2 : pd.DataFrame
-        Table with one row per cluster including ``cluster_descripcion``,
+        Table with one row per cluster including ``cluster_description``,
         ``cluster_ef_sample`` and ``cluster_n_sample`` columns.
     meta : pd.DataFrame
         Metadata indexed by ``rule_token`` providing actionability metrics.
@@ -333,8 +333,8 @@ def experiments_from_df2(
     recs = []
     for (_, row_a), (_, row_b) in itertools.combinations(df2.iterrows(), 2):
 
-        conds_a = set(parse_rule_string(row_a['cluster_descripcion']))
-        conds_b = set(parse_rule_string(row_b['cluster_descripcion']))
+        conds_a = set(parse_rule_string(row_a['cluster_description']))
+        conds_b = set(parse_rule_string(row_b['cluster_description']))
 
         inters     = sorted(conds_a & conds_b)
         only_a     = sorted(conds_a - conds_b)
@@ -436,7 +436,7 @@ def run_experiments(
     Parameters
     ----------
     mx : MetaExtractor
-        Instance used to extract metadata from ``cluster_descripcion`` fields.
+        Instance used to extract metadata from ``cluster_description`` fields.
     df2_dict : dict[str, pd.DataFrame]
         Mapping of dataset name to its corresponding Df2 table.
     data_dict : dict[str, pd.DataFrame], optional

--- a/InsideForest/trees.py
+++ b/InsideForest/trees.py
@@ -101,23 +101,22 @@ class Trees:
     Parameters
     ----------
     regr : estimator
-        Modelo de bosque entrenado.
+        Trained forest model.
     data1 : pandas.DataFrame
-        Conjunto de datos usado para reemplazar los nombres de las
-        características.
+        Dataset used to replace feature names.
     verbose : int, default 0
-        Nivel de verbosidad.
+        Verbosity level.
     percentil : float, optional
-        Percentil para filtrar hojas de los árboles.
+        Percentile to filter tree leaves.
     low_frac : float, optional
-        Fracción de valores por debajo del percentil a muestrear.
+        Fraction of values below the percentile to sample.
     n_jobs : int, default 1
-        Número de trabajos en paralelo. Se emplea ``prefer="threads"`` para
-        evitar el *pickling*. La ejecución en paralelo solo compensa cuando
-        cada árbol es costoso de procesar; en bosques pequeños el modo
-        secuencial reduce la sobrecarga.
+        Number of parallel jobs. Uses ``prefer="threads"`` to avoid
+        pickling. Parallel execution only pays off when each tree is
+        expensive to process; for small forests sequential mode reduces
+        overhead.
     random_state : int, default 0
-        Semilla para operaciones aleatorias.
+        Seed for random operations.
     """
 
     # This function may be slow; add tqdm to the main loop.
@@ -326,11 +325,11 @@ class Trees:
       Parameters
       ----------
       no_branch_lim : int | None, optional
-          Número máximo de árboles a procesar. Si es ``None`` se utilizan
-          todos los árboles disponibles.
+          Maximum number of trees to process. If ``None`` all available
+          trees are used.
       """
 
-      # 1) Calcular el pivot que resume por N_regla, N_arbol, feature, operador
+      # 1) Compute pivot summarizing by N_regla, N_arbol, feature, operator
       agrupacion = pd.pivot_table(
           df_full_arboles,
           index=['N_regla', 'N_arbol', 'feature', 'operador'],
@@ -338,16 +337,16 @@ class Trees:
           aggfunc=['min', 'max', 'mean'],
       )
 
-      # 2) Extraer valores de min y max según el operador
+      # 2) Extract min and max values depending on the operator
       agrupacion_min = agrupacion['min'].reset_index()
       agrupacion_min = agrupacion_min[agrupacion_min['operador'] == '<=']
       agrupacion_max = agrupacion['max'].reset_index()
       agrupacion_max = agrupacion_max[agrupacion_max['operador'] == '>']
 
-      # 3) Concatenar y ordenar
+      # 3) Concatenate and sort
       agrupacion = pd.concat([agrupacion_min, agrupacion_max]).sort_values(['N_arbol', 'N_regla'])
 
-      # 4) Seleccionar los árboles a procesar
+      # 4) Select trees to process
       top_100_arboles = agrupacion['N_arbol'].unique()
       if no_branch_lim is not None:
           top_100_arboles = top_100_arboles[:no_branch_lim]

--- a/tests/test_descrip.py
+++ b/tests/test_descrip.py
@@ -9,7 +9,7 @@ from InsideForest.descrip import (
     categorize_conditions_generalized,
     build_conditions_table,
     _gpt_hypothesis,
-    generar_hypotesis,
+    generate_hypothesis,
     get_frontiers,
 )
 
@@ -61,9 +61,9 @@ def test_build_conditions_table_basic():
     table = build_conditions_table(conds, df, efectiv, ponder, n_groups=3)
     expected = pd.DataFrame(
         {
-            'Grupo': [1, 2],
-            'Efectividad': [0.5, 0.2],
-            'Ponderador': [1.0, 2.0],
+            'Group': [1, 2],
+            'Effectiveness': [0.5, 0.2],
+            'Weight': [1.0, 2.0],
             'Var1': ['Percentile 33.33', 'Percentile 100'],
             'Var2': ['Percentile 33.33', 'Percentile 33.33'],
         }
@@ -112,7 +112,7 @@ def test_generar_hypotesis_fallback_without_gpt(monkeypatch):
         "cluster_ef_b": [0.2],
         "delta_ef": [0.1],
     })
-    result = generar_hypotesis(meta_df, exp_df, target="tok", use_gpt=True, lang="es")
+    result = generate_hypothesis(meta_df, exp_df, target="tok", use_gpt=True, lang="es")
     assert "Etiqueta" in result
 
 
@@ -129,7 +129,7 @@ def test_generar_hypotesis_handles_missing_subgroups(monkeypatch):
         "cluster_ef_b": [0.2],
         "delta_ef": [0.1],
     })
-    result = generar_hypotesis(meta_df, exp_df, target="tok", use_gpt=False, lang="es")
+    result = generate_hypothesis(meta_df, exp_df, target="tok", use_gpt=False, lang="es")
     assert "Etiqueta" in result
 
 
@@ -147,7 +147,7 @@ def test_generar_hypotesis_handles_lowercase_columns(monkeypatch):
         "cluster_ef_b": [0.2],
         "delta_ef": [0.1],
     })
-    result = generar_hypotesis(meta_df, exp_df, target="tok", use_gpt=False, lang="es")
+    result = generate_hypothesis(meta_df, exp_df, target="tok", use_gpt=False, lang="es")
     assert "Etiqueta" in result
     assert "10.00%" in result
 
@@ -156,7 +156,7 @@ def test_get_frontiers_basic():
     df = pd.DataFrame({'x': range(10), 'y': range(10)})
     desc_df = pd.DataFrame({
         'cluster': [0, 1],
-        'cluster_descripcion': [
+        'cluster_description': [
             '0 <= x <= 4 and 0 <= y <= 4',
             '5 <= x <= 9 and 0 <= y <= 4',
         ],
@@ -170,4 +170,4 @@ def test_get_frontiers_basic():
     assert df_explain.loc[df_explain['cluster'] == 0, 'x'].iat[0] == 'PERCENTILE 40'
     assert frontiers.iloc[0]['cluster_1'] == 0
     assert frontiers.iloc[0]['cluster_2'] == 1
-    assert frontiers.iloc[0]['similitud'] == pytest.approx(0.5)
+    assert frontiers.iloc[0]['similarity'] == pytest.approx(0.5)

--- a/tests/test_descrip_helpers.py
+++ b/tests/test_descrip_helpers.py
@@ -16,8 +16,8 @@ from InsideForest.descrip import (
 def _sample_frames():
     df_desc = pd.DataFrame({
         "cluster": [0, 1, 2],
-        "cluster_ponderador": [0.3, 0.5, 0.2],
-        "cluster_descripcion": ["a", "b", "c"],
+        "cluster_weight": [0.3, 0.5, 0.2],
+        "cluster_description": ["a", "b", "c"],
     })
     df_cluster = pd.DataFrame({
         "cluster": [0, 0, 1, 1, 1, 2],
@@ -45,7 +45,7 @@ def test_scale_clusters():
     df_desc, df_cluster = _sample_frames()
     _, _, _, _, valuable = _prepare_cluster_data(df_desc, df_cluster, ["target"])
     scaled = _scale_clusters(valuable)
-    assert "importancia" in scaled.columns
+    assert "importance" in scaled.columns
     assert np.isclose(scaled[0].mean(), 0.0)
     assert np.isclose(scaled[1].mean(), 0.0)
 
@@ -59,8 +59,8 @@ def test_compute_inflection_points():
     updated, p0, p1 = _compute_inflection_points(
         cluster_stats, scaled, 0.4, 0.5
     )
-    assert "buenos" in updated.columns
-    assert updated["buenos"].isin([0, 1]).all()
+    assert "good" in updated.columns
+    assert updated["good"].isin([0, 1]).all()
     assert p0 is not None and p1 is not None
 
 
@@ -80,14 +80,14 @@ def test_merge_outputs():
     final_df = _merge_outputs(sorted_desc, rate_series, updated, {})
     expected_cols = {
         "cluster",
-        "cluster_descripcion",
-        "Probabilidad",
-        "N_probabilidad",
-        "Soporte",
-        "buenos",
+        "cluster_description",
+        "Probability",
+        "N_probability",
+        "Support",
+        "good",
     }
     assert expected_cols.issubset(final_df.columns)
-    assert "cluster_ponderador" not in final_df.columns
+    assert "cluster_weight" not in final_df.columns
 
 
 def test_list_rules_to_text_empty_rule_set_returns_placeholder():

--- a/tests/test_metadata_run_experiments.py
+++ b/tests/test_metadata_run_experiments.py
@@ -15,7 +15,7 @@ def test_run_experiments_includes_intersection_stats():
     # cluster descriptions with a shared rule on x
     df2 = pd.DataFrame({
         'cluster': [0, 1],
-        'cluster_descripcion': [
+        'cluster_description': [
             '0 <= x <= 5 AND 0 <= y <= 5',
             '0 <= x <= 5 AND 5 <= y <= 10',
         ],


### PR DESCRIPTION
## Summary
- Rename Spanish identifiers and comments to English across the codebase
- Standardize column names and helper outputs
- Update tests for new English terminology

## Testing
- `pytest tests/test_descrip.py tests/test_descrip_helpers.py tests/test_metadata_run_experiments.py` *(fails: KeyError: "None of [Index(['TARGET'], dtype='object')] are in the [index]")*


------
https://chatgpt.com/codex/tasks/task_e_68aff691cff4832c9626f6fc207b9c2a