### PR TITLE
Serve documentation as standalone HTML pages

### DIFF
--- a/docs/advanced/hyperparameter.html
+++ b/docs/advanced/hyperparameter.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Receta avanzada: Ajuste fino de hiperparámetros</h1>
+
+<p>Optimizar los parámetros de InsideForest permite mejorar la calidad de los segmentos y la precisión del modelo.</p>
+
+<pre><code>
+from sklearn.model_selection import GridSearchCV
+from insideforest import InsideForestClassifier
+
+param_grid = {
+    &quot;n_clusters&quot;: [5, 10, 15],
+    &quot;n_estimators&quot;: [100, 200],
+    &quot;auto_fast&quot;: [True, False]
+}
+
+grid = GridSearchCV(InsideForestClassifier(), param_grid, cv=3)
+grid.fit(X, y)
+
+print(&quot;Mejor configuración:&quot;, grid.best_params_)
+</code></pre>
+
+<p>Considera utilizar <code>RandomizedSearchCV</code> para espacios de búsqueda más amplios.</p>
+</div>
+</body>
+</html>

--- a/docs/advanced/index.html
+++ b/docs/advanced/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Recetas avanzadas</h1>
+
+<ul>
+<li><a href="hyperparameter.html">Ajuste fino de hiperparámetros</a></li>
+<li><a href="scaling.html">Uso en conjuntos de datos masivos</a></li>
+</ul>
+
+<p>Estas recetas cubren técnicas para obtener el máximo desempeño y escalabilidad de InsideForest.</p>
+</div>
+</body>
+</html>

--- a/docs/advanced/scaling.html
+++ b/docs/advanced/scaling.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Receta avanzada: Uso en conjuntos de datos masivos</h1>
+
+<p>Para escalar InsideForest a millones de registros se recomiendan las siguientes estrategias:</p>
+
+<p>1. <strong>&lt;code&gt;auto_fast=True&lt;/code&gt;</strong>: reduce automáticamente el número de ramas exploradas.</p>
+<p>2. <strong>Submuestreo</strong>: utiliza una muestra representativa para entrenar el bosque y luego aplica el modelo al conjunto completo.</p>
+<p>3. <strong>Paralelismo</strong>: ajusta <code>n_jobs</code> para aprovechar múltiples núcleos.</p>
+<p>4. <strong>Reducción de características</strong>: habilita <code>auto_feature_reduce</code> o aplica técnicas como PCA antes del entrenamiento.</p>
+
+<pre><code>
+clf = InsideForestClassifier(auto_fast=True, n_jobs=-1, auto_feature_reduce=20)
+clf.fit(X_big, y_big)
+</code></pre>
+
+<p>Estas recomendaciones ayudan a mantener tiempos de entrenamiento razonables sin sacrificar demasiada información.</p>
+</div>
+</body>
+</html>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Referencia de API</h1>
+
+<p>Esta sección resume las clases y funciones más importantes de InsideForest. Para generar una documentación más detallada se recomienda utilizar herramientas como <code>pdoc</code> o <code>sphinx-apidoc</code>.</p>
+
+<h2>Clases principales</h2>
+
+<h3>InsideForestClassifier</h3>
+
+<pre><code>
+class InsideForestClassifier(BaseEstimator):
+    def __init__(self, n_clusters=5, n_estimators=100, random_state=None):
+        ...
+    def fit(self, X, y):
+        ...
+    def predict(self, X):
+        ...
+</code></pre>
+
+<h3>InsideForestRegressor</h3>
+
+<pre><code>
+class InsideForestRegressor(BaseEstimator):
+    ...
+</code></pre>
+
+<h2>Submódulos</h2>
+
+<ul>
+<li><code>trees</code></li>
+<li><code>regions</code></li>
+<li><code>descrip</code></li>
+<li><code>labels</code></li>
+<li><code>cluster_selector</code></li>
+</ul>
+
+<p>Consulta el código fuente en el repositorio para obtener información completa sobre parámetros y valores de retorno.</p>
+</div>
+</body>
+</html>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Blog / Noticias</h1>
+
+<p>Aquí se publicarán anuncios, artículos y novedades sobre InsideForest. ¡Mantente al tanto para conocer nuevas versiones y casos de uso!</p>
+</div>
+</body>
+</html>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Notas de versión</h1>
+
+<h2>v1.0</h2>
+<ul>
+<li>Lanzamiento inicial de InsideForest.</li>
+<li>Soporte para clasificación y regresión.</li>
+</ul>
+
+<h2>v1.1 (en desarrollo)</h2>
+<ul>
+<li>Documentación ampliada y estructura para GitHub Pages.</li>
+</ul>
+</div>
+</body>
+</html>

--- a/docs/community/index.html
+++ b/docs/community/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Comunidad</h1>
+
+<ul>
+<li>Únete a nuestro [servidor de Discord](https://discord.gg/tu-servidor) para discutir ideas y recibir soporte.</li>
+<li>Para reportar vulnerabilidades, envía un correo a <strong>security@insideforest.org</strong>.</li>
+</ul>
+</div>
+</body>
+</html>

--- a/docs/contributing/index.html
+++ b/docs/contributing/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Contribuir</h1>
+
+<p>Tu ayuda es bienvenida. Antes de enviar cambios sigue estas recomendaciones.</p>
+
+<h2>Flujo de trabajo</h2>
+
+<p>1. Haz un <em>fork</em> del repositorio.</p>
+<p>2. Crea una rama descriptiva para tu aporte.</p>
+<p>3. Asegúrate de que <code>pre-commit</code> y <code>pytest</code> pasen sin errores.</p>
+<p>4. Abre un Pull Request detallando los cambios.</p>
+
+<h2>Plantillas</h2>
+
+<p>Utiliza las plantillas de issues y PRs para mantener la consistencia.</p>
+
+<h2>Código de conducta</h2>
+
+<p>Todos los participantes deben respetar nuestro <a href="../CODE_OF_CONDUCT.html">código de conducta</a> si está disponible.</p>
+</div>
+</body>
+</html>

--- a/docs/development/index.html
+++ b/docs/development/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Sección de desarrollo</h1>
+
+<p>Esta sección describe cómo instalar InsideForest en modo editable, ejecutar los tests y contribuir con nuevas funcionalidades.</p>
+
+<h2>Instalación local</h2>
+
+<pre><code>
+git clone https://github.com/tu-organizacion/InsideForest.git
+cd InsideForest
+pip install -e .
+</code></pre>
+
+<h2>Ejecutar tests y estilo</h2>
+
+<pre><code>
+pre-commit run --all-files
+pytest
+</code></pre>
+
+<h2>Estructura del repositorio</h2>
+
+<ul>
+<li><code>src/</code>: código fuente principal.</li>
+<li><code>tests/</code>: pruebas automatizadas.</li>
+<li><code>data/</code>: datasets de ejemplo.</li>
+</ul>
+
+<p>Sigue las convenciones de estilo definidas por <code>black</code> y <code>flake8</code> (si están configuradas en el proyecto) y procura añadir pruebas para cada nueva funcionalidad.</p>
+</div>
+</body>
+</html>

--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Casos de uso</h1>
+
+<ul>
+<li><a href="marketing.html">Segmentación de clientes</a></li>
+</ul>
+
+<p>Agrega aquí más ejemplos completos adaptados a tus datos.</p>
+</div>
+</body>
+</html>

--- a/docs/examples/marketing.html
+++ b/docs/examples/marketing.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Ejemplo: Segmentación de clientes</h1>
+
+<p>Este caso de uso muestra cómo aplicar InsideForest para segmentar clientes de una tienda en línea en función de su comportamiento.</p>
+
+<h2>1. Datos</h2>
+
+<p>Supongamos que contamos con datos de compras, visitas y categoría de usuario.</p>
+
+<h2>2. Entrenamiento</h2>
+
+<pre><code>
+from insideforest import InsideForestClassifier
+
+clf = InsideForestClassifier(n_clusters=6)
+clf.fit(X_clientes, y_clientes)
+</code></pre>
+
+<h2>3. Descripción de segmentos</h2>
+
+<pre><code>
+for seg in clf.describe_segments(top_k=5):
+    print(seg[&quot;description&quot;], &quot;-&gt;&quot;, seg[&quot;support&quot;])
+</code></pre>
+
+<h2>4. Interpretación</h2>
+
+<p>Las reglas generadas ayudan a entender qué características definen a los grupos de clientes más rentables o con mayor riesgo de abandono.</p>
+</div>
+</body>
+</html>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Preguntas frecuentes</h1>
+
+<h2>¿En qué se diferencia InsideForest de un RandomForest?</h2>
+<p>InsideForest añade una capa de interpretación que describe segmentos del espacio de características utilizando las etiquetas como guía.</p>
+
+<h2>¿Cómo elijo el número de clústeres?</h2>
+<p>Prueba varios valores de <code>n_clusters</code> y evalúa con métricas internas y externas como precisión, recall o <em>silhouette</em>.</p>
+
+<h2>¿Puedo usar InsideForest con datos desbalanceados?</h2>
+<p>Sí, considera ajustar los pesos de clase o aplicar técnicas de sobremuestreo antes del entrenamiento.</p>
+
+<h2>¿Existe soporte para series temporales?</h2>
+<p>Actualmente no, pero está contemplado en el <a href="roadmap.html">roadmap</a>.</p>
+</div>
+</body>
+</html>

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Guía de inicio rápido</h1>
+
+<p>Esta guía te acompañará en los primeros pasos con InsideForest, desde la instalación hasta la ejecución del primer ejemplo.</p>
+
+<h2>1. Instalación</h2>
+
+<p>InsideForest requiere <strong>Python 3.8+</strong>. La forma recomendada de instalar es mediante <code>pip</code> desde PyPI:</p>
+
+<pre><code>
+pip install insideforest
+</code></pre>
+
+<p>Para probar la versión en desarrollo directamente desde el repositorio:</p>
+
+<pre><code>
+pip install git+https://github.com/tu-organizacion/InsideForest.git
+</code></pre>
+
+<h2>2. Hola Mundo</h2>
+
+<p>El siguiente ejemplo muestra cómo entrenar un clasificador simple usando el conocido dataset de Iris.</p>
+
+<pre><code>
+from insideforest import InsideForestClassifier
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+
+X, y = load_iris(return_X_y=True)
+X_tr, X_te, y_tr, y_te = train_test_split(X, y, test_size=0.3, random_state=0)
+
+clf = InsideForestClassifier()
+clf.fit(X_tr, y_tr)
+
+print(&quot;Precision:&quot;, clf.score(X_te, y_te))
+</code></pre>
+
+<h2>3. Flujo básico de trabajo</h2>
+
+<p>1. <strong>Entrenar</strong> un modelo con datos etiquetados.</p>
+<p>2. <strong>Extraer ramas</strong> que dividen el espacio de características.</p>
+<p>3. <strong>Priorizar regiones</strong> y agrupar instancias similares.</p>
+<p>4. <strong>Describir</strong> cada segmento con reglas interpretables.</p>
+
+<p>Este flujo garantiza que los resultados sean transparentes y fáciles de explicar.</p>
+
+<h2>4. Próximos pasos</h2>
+
+<ul>
+<li>Revisa los <a href="../tutorials/classification.html">tutoriales paso a paso</a>.</li>
+<li>Explora las <a href="../guides/architecture.html">guías de uso</a>.</li>
+<li>Consulta la <a href="../api/index.html">referencia de API</a>.</li>
+</ul>
+</div>
+</body>
+</html>

--- a/docs/glossary.html
+++ b/docs/glossary.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Glosario</h1>
+
+<ul>
+<li><strong>Rama</strong>: conjunto de reglas derivadas de un árbol de decisión.</li>
+<li><strong>Región</strong>: intersección de varias ramas que define un segmento del espacio de características.</li>
+<li><strong>Supervised clustering</strong>: técnica que utiliza etiquetas conocidas para guiar la formación de clústeres.</li>
+<li><strong>Segmento</strong>: grupo de instancias que comparte características similares y una etiqueta predominante.</li>
+</ul>
+</div>
+</body>
+</html>

--- a/docs/guides/architecture.html
+++ b/docs/guides/architecture.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Guía: Arquitectura interna</h1>
+
+<p>InsideForest se compone de varios módulos que interactúan para ofrecer interpretabilidad desde la fase de entrenamiento.</p>
+
+<h2>Módulos principales</h2>
+
+<p>| Módulo | Descripción |</p>
+<p>|--------|-------------|</p>
+<p>| <code>trees</code> | Construye y analiza los árboles de decisión subyacentes. |</p>
+<p>| <code>regions</code> | Define y prioriza intersecciones de ramas para formar segmentos. |</p>
+<p>| <code>descrip</code> | Genera descripciones legibles de cada región. |</p>
+<p>| <code>cluster_selector</code> | Selecciona clústeres significativos empleando criterios supervisados. |</p>
+
+<h2>Flujo de datos</h2>
+
+<p>1. <strong>Entrenamiento</strong>: se ajusta un bosque de árboles de decisión sobre los datos etiquetados.</p>
+<p>2. <strong>Extracción de ramas</strong>: cada árbol se recorre para identificar reglas de decisión.</p>
+<p>3. <strong>Combinación</strong>: las ramas se combinan para formar regiones con características similares.</p>
+<p>4. <strong>Selección</strong>: se priorizan las regiones más informativas con respecto a las etiquetas.</p>
+<p>5. <strong>Descripción</strong>: se sintetizan reglas en lenguaje natural o representaciones tabulares.</p>
+
+<p>Este diseño modular facilita extender o reemplazar componentes sin alterar el resto del sistema.</p>
+</div>
+</body>
+</html>

--- a/docs/guides/config.html
+++ b/docs/guides/config.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Guía: Configuración y parámetros</h1>
+
+<p>Los modelos de InsideForest aceptan numerosos parámetros que controlan el número de árboles, la cantidad de clústeres y la estrategia de búsqueda.</p>
+
+<pre><code>
+InsideForestClassifier(
+    n_estimators=100,
+    n_clusters=10,
+    auto_fast=False,
+    rf_params=None,
+    tree_params=None
+)
+</code></pre>
+
+<h2>Parámetros destacados</h2>
+
+<ul>
+<li><strong>n_estimators</strong>: número de árboles en el bosque base.</li>
+<li><strong>n_clusters</strong>: cantidad de segmentos a priorizar.</li>
+<li><strong>auto_fast</strong>: activa ajustes automáticos para acelerar el entrenamiento.</li>
+<li><strong>rf_params</strong> y <strong>tree_params</strong>: diccionarios con opciones avanzadas para <code>RandomForest</code> y árboles individuales.</li>
+</ul>
+
+<h2>Estrategias de búsqueda</h2>
+
+<p>Se puede utilizar <code>GridSearchCV</code> o <code>RandomizedSearchCV</code> para optimizar los parámetros. Revisa los <a href="../tutorials/pipeline.html">tutoriales</a> para ver un ejemplo.</p>
+</div>
+</body>
+</html>

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Guías de uso</h1>
+
+<ul>
+<li><a href="architecture.html">Arquitectura interna</a></li>
+<li><a href="config.html">Configuración y parámetros</a></li>
+<li><a href="interpretation.html">Interpretación de resultados</a></li>
+</ul>
+</div>
+</body>
+</html>

--- a/docs/guides/interpretation.html
+++ b/docs/guides/interpretation.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Guía: Interpretación de resultados</h1>
+
+<p>InsideForest busca ofrecer interpretaciones claras para cada segmento encontrado.</p>
+
+<h2>Importancia de variables</h2>
+
+<pre><code>
+importances = clf.feature_importances_
+for feat, imp in zip(X.columns, importances):
+    print(feat, round(imp, 3))
+</code></pre>
+
+<h2>Descripciones de segmentos</h2>
+
+<pre><code>
+descriptions = clf.describe_segments(top_k=3)
+for desc in descriptions:
+    print(desc[&quot;description&quot;])
+</code></pre>
+
+<p>Cada descripción resume las condiciones que definen un grupo de instancias y puede utilizarse para generar reportes.</p>
+
+<h2>Visualizaciones</h2>
+
+<p>Puedes exportar los resultados a formatos como CSV o JSON y usar librerías de visualización (ej. <code>plotly</code>) para explorar interactivamente las regiones.</p>
+</div>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8" />
+    <title>InsideForest - Documentación</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <div class="main-content">
+<h1>InsideForest <span class="badge">v1.0</span></h1>
+        <section id="inicio" class="section">
+            <h2>Página principal</h2>
+            <p>InsideForest es una librería de <em>machine learning</em> que permite un enfoque interpretativo y supervisado para agrupar datos mediante árboles de decisión y extracción de segmentos. Esta documentación provee recursos completos para usar y contribuir al proyecto.</p>
+            <div class="example">
+                <h3>Ejemplo rápido</h3>
+                <pre><code class="language-python">from insideforest import InsideForestClassifier
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+
+X, y = load_iris(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3)
+
+clf = InsideForestClassifier()
+clf.fit(X_train, y_train)
+print("Precisión:", clf.score(X_test, y_test))
+</code></pre>
+            </div>
+        </section>
+
+        <section id="guia-rapida" class="section">
+            <h2>Guía de inicio rápido</h2>
+            <h3>Instalación</h3>
+            <pre><code class="language-bash">pip install insideforest</code></pre>
+            <div class="note">
+                <strong>Tip:</strong> Instala la versión de desarrollo:
+                <pre><code class="language-bash">pip install git+https://github.com/tu-organizacion/InsideForest.git</code></pre>
+            </div>
+            <h3>Hola Mundo</h3>
+            <pre><code class="language-python">from insideforest import InsideForestClassifier
+from sklearn.datasets import load_iris
+
+X, y = load_iris(return_X_y=True)
+model = InsideForestClassifier()
+model.fit(X, y)
+print("Clases:", model.classes_)
+</code></pre>
+            <h3>Workflow básico</h3>
+            <p>Entrenar → extraer segmentos → etiquetar → describir.</p>
+        </section>
+
+        <section id="tutoriales" class="section">
+            <h2>Tutoriales paso a paso</h2>
+            <h3>Clasificación supervisada básica</h3>
+            <pre><code class="language-python">from insideforest import InsideForestClassifier
+from sklearn.datasets import load_wine
+from sklearn.model_selection import train_test_split
+import pandas as pd
+
+X, y = load_wine(return_X_y=True, as_frame=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y)
+
+clf = InsideForestClassifier(n_clusters=5, auto_fast=True)
+clf.fit(X_train, y_train)
+segments = clf.get_segments()
+print(pd.DataFrame(segments).head())
+</code></pre>
+            <h3>Regresión supervisada</h3>
+            <pre><code class="language-python">from insideforest import InsideForestRegressor
+from sklearn.datasets import load_diabetes
+
+X, y = load_diabetes(return_X_y=True)
+reg = InsideForestRegressor(n_estimators=200)
+reg.fit(X, y)
+print(reg.predict(X[:5]))
+</code></pre>
+            <h3>Guardado y carga de modelos</h3>
+            <pre><code class="language-python">import joblib
+from insideforest import InsideForestClassifier
+
+clf = InsideForestClassifier()
+clf.fit(X_train, y_train)
+joblib.dump(clf, "modelo_iforest.pkl")
+loaded = joblib.load("modelo_iforest.pkl")
+</code></pre>
+        </section>
+
+        <section id="guia-uso" class="section">
+            <h2>Guías de uso</h2>
+            <h3>Conceptos clave</h3>
+            <p>InsideForest se basa en <em>supervised clustering</em>, donde los clústeres se forman con ayuda de etiquetas.</p>
+            <h3>Arquitectura interna</h3>
+            <p>El sistema se compone de módulos como <code>trees</code>, <code>regions</code>, <code>descrip</code>, etc. Cada uno cumple funciones específicas.</p>
+            <h3>Configuración y parámetros</h3>
+            <pre><code class="language-python">InsideForestClassifier(
+    n_estimators=100,
+    n_clusters=10,
+    auto_fast=False,
+    rf_params=None,
+    tree_params=None
+)
+</code></pre>
+            <h3>Interpretación de resultados</h3>
+            <pre><code class="language-python">importances = clf.feature_importances_
+for feature, importance in zip(X.columns, importances):
+    print(feature, importance)
+</code></pre>
+        </section>
+
+        <section id="api" class="section">
+            <h2>Referencia de API</h2>
+            <h3>InsideForestClassifier</h3>
+            <pre><code class="language-python">class InsideForestClassifier(BaseEstimator):
+    def __init__(self, n_clusters=5, n_estimators=100, random_state=None):
+        """Constructor"""
+    def fit(self, X, y):
+        """Entrena el modelo"""
+    def predict(self, X):
+        """Predice etiquetas"""
+</code></pre>
+            <h3>InsideForestRegressor</h3>
+            <pre><code class="language-python">class InsideForestRegressor(BaseEstimator):
+    ...
+</code></pre>
+        </section>
+
+        <section id="ejemplos" class="section">
+            <h2>Casos de uso y ejemplos completos</h2>
+            <h3>Segmentación de clientes en marketing</h3>
+            <pre><code class="language-python">segmentos = clf.describe_segments(top_k=3)
+for seg in segmentos:
+    print(seg["description"])
+</code></pre>
+            <h3>Ejemplo con dataset Iris</h3>
+            <p>Consulta nuestro <a href="https://colab.research.google.com">notebook</a> para probar InsideForest en tu navegador.</p>
+        </section>
+
+        <section id="avanzado" class="section">
+            <h2>Recetas avanzadas</h2>
+            <h3>Ajuste fino de hiperparámetros</h3>
+            <pre><code class="language-python">from sklearn.model_selection import GridSearchCV
+param_grid = {
+    "n_clusters": [5, 10, 15],
+    "n_estimators": [100, 200]
+}
+
+grid = GridSearchCV(InsideForestClassifier(), param_grid, cv=3)
+grid.fit(X, y)
+print("Mejor configuración:", grid.best_params_)
+</code></pre>
+            <h3>Uso en datasets masivos</h3>
+            <p>Usa <code>auto_fast=True</code> y <code>auto_feature_reduce</code> para mejorar tiempos.</p>
+        </section>
+
+        <section id="desarrollo" class="section">
+            <h2>Sección de desarrollo</h2>
+            <h3>Instalación local</h3>
+            <pre><code class="language-bash">git clone https://github.com/tu-organizacion/InsideForest.git
+cd InsideForest
+pip install -e .
+</code></pre>
+            <h3>Ejecución de tests y estilo</h3>
+            <pre><code class="language-bash">pre-commit run --all-files
+pytest
+</code></pre>
+        </section>
+
+        <section id="contribuir" class="section">
+            <h2>Contribuir</h2>
+            <h3>Pull Requests</h3>
+            <ul>
+                <li>Haz un fork del repositorio.</li>
+                <li>Crea una rama descriptiva.</li>
+                <li>Incluye pruebas y documentación.</li>
+                <li>Solicita revisión vía PR.</li>
+            </ul>
+            <h3>Código de conducta</h3>
+            <p>Todos los colaboradores deben adherirse al <a href="CODE_OF_CONDUCT.html">Código de conducta</a>.</p>
+        </section>
+
+        <section id="faq" class="section">
+            <h2>Preguntas frecuentes</h2>
+            <h3>¿Cuál es la diferencia con un RandomForest?</h3>
+            <p>InsideForest incorpora mecanismos para interpretar los segmentos y unirlos con etiquetas supervisadas.</p>
+            <h3>¿Cómo seleccionar el número de clústeres?</h3>
+            <p>Prueba varios valores y evalúa con métricas internas y externas.</p>
+        </section>
+
+        <section id="problemas" class="section">
+            <h2>Solución de problemas</h2>
+            <pre><code class="language-bash"># Ejemplo: error por versión de numpy
+pip install --upgrade numpy
+</code></pre>
+        </section>
+
+        <section id="glosario" class="section">
+            <h2>Glosario</h2>
+            <ul>
+                <li><strong>Rama</strong>: subconjunto de reglas derivadas de un árbol.</li>
+                <li><strong>Región</strong>: intersección de varias ramas.</li>
+                <li><strong>Supervised clustering</strong>: agrupamiento asistido por etiquetas.</li>
+            </ul>
+        </section>
+
+        <section id="changelog" class="section">
+            <h2>Notas de versión</h2>
+            <h3>v1.0</h3>
+            <ul>
+                <li>Lanzamiento inicial de InsideForest.</li>
+                <li>Soporte para clasificación y regresión.</li>
+            </ul>
+        </section>
+
+        <section id="roadmap" class="section">
+            <h2>Roadmap</h2>
+            <ul>
+                <li>Soporte para series temporales.</li>
+                <li>Integración con bibliotecas de visualización.</li>
+                <li>Optimización de inferencia en tiempo real.</li>
+            </ul>
+        </section>
+
+        <section id="licencia" class="section">
+            <h2>Licencia y créditos</h2>
+            <p>InsideForest se distribuye bajo la licencia MIT. Consulta <a href="LICENSE.html">LICENSE</a>.</p>
+            <p>Agradecimientos a todos los colaboradores.</p>
+        </section>
+
+        <section id="blog" class="section">
+            <h2>Blog / Noticias</h2>
+            <p>Próximamente publicaremos artículos y novedades sobre InsideForest.</p>
+        </section>
+
+        <section id="recursos" class="section">
+            <h2>Recursos externos</h2>
+            <ul>
+                <li><a href="paper.html">Paper original</a></li>
+                <li><a href="https://colab.research.google.com">Notebooks de demostración</a></li>
+                <li><a href="https://youtu.be/XYZ123">Presentaciones y charlas</a></li>
+            </ul>
+        </section>
+
+        <section id="comunidad" class="section">
+            <h2>Contactos y comunidad</h2>
+            <p>Únete a nuestro <a href="https://discord.gg/tu-servidor">servidor de Discord</a> para discutir ideas y recibir soporte.</p>
+            <p>Para reportar vulnerabilidades de seguridad, envía un correo a <strong>security@insideforest.org</strong>.</p>
+        </section>
+    </div>
+</body>
+</html>

--- a/docs/license.html
+++ b/docs/license.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Licencia</h1>
+
+<p>InsideForest se distribuye bajo la licencia MIT. Consulta el archivo <a href="../LICENSE">LICENSE</a> en la raíz del repositorio para conocer los detalles completos y los términos de uso.</p>
+</div>
+</body>
+</html>

--- a/docs/paper.html
+++ b/docs/paper.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Paper técnico</title>
+<link rel='stylesheet' href='style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Paper técnico de InsideForest</h1>
+<p>Este documento resume el paper <em>InsideForest: un enfoque interpretativo para el clustering supervisado</em>, donde se describen los fundamentos teóricos y la arquitectura de la librería.</p>
+
+<h2>Resumen</h2>
+<p>InsideForest combina bosques aleatorios con técnicas de <strong>supervised clustering</strong> para generar segmentos explicables. Cada región resultante se describe mediante reglas basadas en intervalos y se acompaña de métricas como soporte, pureza y lift.</p>
+
+<h2>Ejemplo de código</h2>
+<pre><code class="language-python">
+from insideforest import InsideForestClassifier
+from sklearn.datasets import load_iris
+
+X, y = load_iris(return_X_y=True)
+clf = InsideForestClassifier()
+clf.fit(X, y)
+segments = clf.get_segments()
+print(segments[:3])
+</code></pre>
+
+<p>El documento completo, con demostraciones formales y resultados experimentales, está disponible en el archivo <code><a href="../README.paper.md">README.paper.md</a></code> del repositorio.</p>
+</div>
+</body>
+</html>

--- a/docs/resources.html
+++ b/docs/resources.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Recursos externos</h1>
+<ul>
+<li><a href="paper.html">Paper original</a></li>
+<li><a href="https://colab.research.google.com">Notebooks de demostración</a></li>
+<li><a href="https://youtu.be/XYZ123">Presentaciones y charlas</a></li>
+</ul>
+</div>
+</body>
+</html>

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Roadmap</h1>
+
+<ul>
+<li>Soporte para series temporales.</li>
+<li>Integración con bibliotecas de visualización.</li>
+<li>Optimización de inferencia en tiempo real.</li>
+<li>Traducciones adicionales de la documentación.</li>
+</ul>
+</div>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,74 @@
+/* Scope all custom styles to the main content area so that the
+   default layout from the just-the-docs theme is not disrupted. */
+:root {
+  --primary-color: #1e6091;
+  --accent-color: #ff6b6b;
+  --text-color: #2b2d42;
+  --background-color: #f8fafc;
+  --code-bg: #e2e8f0;
+  --border-color: #cbd5e1;
+}
+
+.main-content {
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
+  background-color: var(--background-color);
+  color: var(--text-color);
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.main-content h1,
+.main-content h2,
+.main-content h3 {
+  color: var(--primary-color);
+}
+
+.main-content a {
+  color: var(--accent-color);
+}
+
+.main-content a:hover {
+  color: var(--primary-color);
+}
+
+.main-content code {
+  font-family: "Source Code Pro", Menlo, monospace;
+  background: var(--code-bg);
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+}
+
+.main-content pre code {
+  background: none;
+  padding: 0;
+  display: block;
+}
+
+.main-content pre {
+  background: var(--code-bg);
+  padding: 1rem;
+  overflow-x: auto;
+  border-left: 4px solid var(--primary-color);
+  border-radius: 4px;
+}
+
+.main-content .doc-image {
+  text-align: center;
+  margin: 2rem 0;
+}
+
+.main-content .doc-image img {
+  max-width: 100%;
+  height: auto;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.main-content .scroll-table {
+  max-height: 400px;
+  overflow-y: auto;
+  margin-bottom: 1.5rem;
+}

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Solución de problemas</h1>
+
+<h2>Error de instalación</h2>
+<p>Asegúrate de tener una versión reciente de <code>pip</code> y <code>setuptools</code>:</p>
+
+<pre><code>
+pip install --upgrade pip setuptools
+</code></pre>
+
+<h2>Modelos lentos</h2>
+<ul>
+<li>Activa <code>auto_fast=True</code>.</li>
+<li>Reduce el número de características o registros.</li>
+<li>Usa paralelismo con <code>n_jobs</code>.</li>
+</ul>
+
+<h2>Problemas durante el entrenamiento</h2>
+<p>Verifica que no existan valores nulos y que las etiquetas estén bien formadas. Si el problema persiste, abre un issue en el repositorio.</p>
+</div>
+</body>
+</html>

--- a/docs/tutorials/classification.html
+++ b/docs/tutorials/classification.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Tutorial: Clasificación supervisada básica</h1>
+
+<p>En este tutorial aprenderás a entrenar un <code>InsideForestClassifier</code> y a interpretar los segmentos resultantes.</p>
+
+<h2>1. Preparar los datos</h2>
+
+<p>Usaremos el dataset de vinos de <code>sklearn</code>, que incluye 13 características químicas por muestra.</p>
+
+<pre><code>
+from sklearn.datasets import load_wine
+from sklearn.model_selection import train_test_split
+import pandas as pd
+
+X, y = load_wine(return_X_y=True, as_frame=True)
+X_tr, X_te, y_tr, y_te = train_test_split(X, y, random_state=0)
+</code></pre>
+
+<h2>2. Entrenar el modelo</h2>
+
+<pre><code>
+from insideforest import InsideForestClassifier
+
+clf = InsideForestClassifier(n_clusters=5, auto_fast=True)
+clf.fit(X_tr, y_tr)
+</code></pre>
+
+<h2>3. Interpretar segmentos</h2>
+
+<p>El modelo genera segmentos que resumen las reglas de decisión más relevantes.</p>
+
+<pre><code>
+segments = clf.get_segments()
+print(pd.DataFrame(segments).head())
+</code></pre>
+
+<p>Cada fila representa una región en el espacio de características y puede describirse como una regla legible.</p>
+
+<h2>4. Evaluación</h2>
+
+<pre><code>
+print(&quot;Precisión:&quot;, clf.score(X_te, y_te))
+</code></pre>
+
+<h2>5. Variaciones sugeridas</h2>
+
+<ul>
+<li>Cambiar <code>n_clusters</code> para ajustar el número de segmentos.</li>
+<li>Usar <code>auto_feature_reduce=True</code> para datasets con muchas variables.</li>
+<li>Habilitar <code>rf_params</code> personalizados para controlar el bosque subyacente.</li>
+</ul>
+</div>
+</body>
+</html>

--- a/docs/tutorials/index.html
+++ b/docs/tutorials/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Tutoriales</h1>
+
+<ul>
+<li><a href="classification.html">Clasificación supervisada básica</a></li>
+<li><a href="regression.html">Regresión supervisada</a></li>
+<li><a href="pipeline.html">Integración con pipelines de scikit-learn</a></li>
+<li><a href="persistence.html">Guardado y carga de modelos</a></li>
+</ul>
+</div>
+</body>
+</html>

--- a/docs/tutorials/persistence.html
+++ b/docs/tutorials/persistence.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Tutorial: Guardado y carga de modelos</h1>
+
+<p>Es frecuente querer almacenar un modelo entrenado para reutilizarlo más adelante. InsideForest es compatible con <code>joblib</code>.</p>
+
+<pre><code>
+import joblib
+from insideforest import InsideForestClassifier
+
+clf = InsideForestClassifier()
+clf.fit(X_tr, y_tr)
+
+joblib.dump(clf, &quot;modelo_iforest.pkl&quot;)
+
+loaded = joblib.load(&quot;modelo_iforest.pkl&quot;)
+print(&quot;Modelo cargado, precisión:&quot;, loaded.score(X_te, y_te))
+</code></pre>
+
+<p>Guarda los artefactos generados por <code>InsideForest</code> junto a metadatos de la versión utilizada para asegurar reproducibilidad.</p>
+</div>
+</body>
+</html>

--- a/docs/tutorials/pipeline.html
+++ b/docs/tutorials/pipeline.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Tutorial: Integración con pipelines de scikit-learn</h1>
+
+<p>InsideForest puede integrarse en un <code>Pipeline</code> de <code>sklearn</code> para combinar preprocesamiento, selección de características y entrenamiento.</p>
+
+<pre><code>
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.model_selection import GridSearchCV
+from insideforest import InsideForestClassifier
+
+pipe = Pipeline([
+    (&quot;scaler&quot;, StandardScaler()),
+    (&quot;model&quot;, InsideForestClassifier())
+])
+
+param_grid = {
+    &quot;model__n_clusters&quot;: [5, 10],
+    &quot;model__n_estimators&quot;: [100, 200]
+}
+
+grid = GridSearchCV(pipe, param_grid, cv=3)
+grid.fit(X, y)
+
+print(&quot;Mejores parámetros:&quot;, grid.best_params_)
+</code></pre>
+
+<p>Este enfoque facilita el ajuste fino de hiperparámetros y la reproducibilidad de experimentos.</p>
+</div>
+</body>
+</html>

--- a/docs/tutorials/regression.html
+++ b/docs/tutorials/regression.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang='es'>
+<head>
+<meta charset='UTF-8' />
+<title>InsideForest - Documentación</title>
+<link rel='stylesheet' href='../style.css' />
+</head>
+<body>
+<div class="main-content">
+<h1>Tutorial: Regresión supervisada</h1>
+
+<p>InsideForest también permite resolver problemas de regresión mediante <code>InsideForestRegressor</code>.</p>
+
+<h2>1. Dataset de ejemplo</h2>
+
+<p>Usaremos el dataset de diabetes de <code>sklearn</code>, que contiene 10 variables numéricas por paciente.</p>
+
+<pre><code>
+from sklearn.datasets import load_diabetes
+
+X, y = load_diabetes(return_X_y=True)
+</code></pre>
+
+<h2>2. Entrenar el modelo</h2>
+
+<pre><code>
+from insideforest import InsideForestRegressor
+
+reg = InsideForestRegressor(n_estimators=200)
+reg.fit(X, y)
+</code></pre>
+
+<h2>3. Predicción</h2>
+
+<pre><code>
+preds = reg.predict(X[:5])
+print(preds)
+</code></pre>
+
+<h2>4. Evaluación rápida</h2>
+
+<pre><code>
+from sklearn.metrics import r2_score
+print(&quot;R2:&quot;, r2_score(y[:5], preds))
+</code></pre>
+
+<h2>5. Consejos</h2>
+
+<ul>
+<li>Para datasets grandes considera <code>auto_fast=True</code>.</li>
+<li>Ajusta <code>n_estimators</code> para equilibrar precisión y tiempo de entrenamiento.</li>
+</ul>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scope documentation styling with CSS variables and `.main-content` wrapper
- add paper summary page and link it from resources

## Testing
- `pre-commit run --all-files` *(command not found)*
- `pytest` *(KeyboardInterrupt after 29 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b77ff609a8832cbd7e718995663434