### PR TITLE
feat(docs): refine layout and add benchmarks

### DIFF
--- a/docs/advanced/hyperparameter.html
+++ b/docs/advanced/hyperparameter.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Receta avanzada: Ajuste fino de hiperparámetros</h1>
 
@@ -29,5 +31,6 @@ print(&quot;Mejor configuración:&quot;, grid.best_params_)
 
 <p>Considera utilizar <code>RandomizedSearchCV</code> para espacios de búsqueda más amplios.</p>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/advanced/index.html
+++ b/docs/advanced/index.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Recetas avanzadas</h1>
 
@@ -16,5 +18,6 @@
 
 <p>Estas recetas cubren técnicas para obtener el máximo desempeño y escalabilidad de InsideForest.</p>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/advanced/scaling.html
+++ b/docs/advanced/scaling.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Receta avanzada: Uso en conjuntos de datos masivos</h1>
 
@@ -23,5 +25,6 @@ clf.fit(X_big, y_big)
 
 <p>Estas recomendaciones ayudan a mantener tiempos de entrenamiento razonables sin sacrificar demasiada información.</p>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Referencia de API</h1>
 
@@ -44,5 +46,6 @@ class InsideForestRegressor(BaseEstimator):
 
 <p>Consulta el código fuente en el repositorio para obtener información completa sobre parámetros y valores de retorno.</p>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>InsideForest - Benchmarks</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav id="sidebar"></nav>
+  <div class="main-content">
+    <h1>Benchmarks</h1>
+    <p>Resultados de rendimiento en el dataset de Iris comparando diferentes métodos de InsideForest.</p>
+    <div class="doc-image">
+      <img src="../data/plot_1.png" alt="Resultados de precisión" />
+    </div>
+    <div class="doc-image">
+      <img src="../data/plot_2.png" alt="Tiempos de ejecución" />
+    </div>
+    <p>Resumen de métricas:</p>
+    <div class="scroll-table">
+      <table>
+        <thead>
+          <tr><th>Método</th><th>Accuracy</th><th>Runtime (s)</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>select_clusters</td><td>0.65</td><td>3.97</td></tr>
+          <tr><td>balance_lists_n_clusters</td><td>0.90</td><td>0.56</td></tr>
+          <tr><td>max_prob_clusters</td><td>0.65</td><td>0.27</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <script src="sidebar.js"></script>
+</body>
+</html>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -6,10 +6,13 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Blog / Noticias</h1>
 
 <p>Aquí se publicarán anuncios, artículos y novedades sobre InsideForest. ¡Mantente al tanto para conocer nuevas versiones y casos de uso!</p>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Notas de versión</h1>
 
@@ -20,5 +22,6 @@
 <li>Documentación ampliada y estructura para GitHub Pages.</li>
 </ul>
 </div>
+  <script src="sidebar.js"></script>
 </body>
 </html>

--- a/docs/community/index.html
+++ b/docs/community/index.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Comunidad</h1>
 
@@ -14,5 +16,6 @@
 <li>Para reportar vulnerabilidades, envía un correo a <strong>security@insideforest.org</strong>.</li>
 </ul>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/contributing/index.html
+++ b/docs/contributing/index.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Contribuir</h1>
 
@@ -26,5 +28,6 @@
 
 <p>Todos los participantes deben respetar nuestro <a href="../CODE_OF_CONDUCT.html">código de conducta</a> si está disponible.</p>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/development/index.html
+++ b/docs/development/index.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Sección de desarrollo</h1>
 
@@ -36,5 +38,6 @@ pytest
 
 <p>Sigue las convenciones de estilo definidas por <code>black</code> y <code>flake8</code> (si están configuradas en el proyecto) y procura añadir pruebas para cada nueva funcionalidad.</p>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Casos de uso</h1>
 
@@ -15,5 +17,6 @@
 
 <p>Agrega aquí más ejemplos completos adaptados a tus datos.</p>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/examples/marketing.html
+++ b/docs/examples/marketing.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Ejemplo: Segmentación de clientes</h1>
 
@@ -35,5 +37,6 @@ for seg in clf.describe_segments(top_k=5):
 
 <p>Las reglas generadas ayudan a entender qué características definen a los grupos de clientes más rentables o con mayor riesgo de abandono.</p>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Preguntas frecuentes</h1>
 
@@ -21,5 +23,6 @@
 <h2>¿Existe soporte para series temporales?</h2>
 <p>Actualmente no, pero está contemplado en el <a href="roadmap.html">roadmap</a>.</p>
 </div>
+  <script src="sidebar.js"></script>
 </body>
 </html>

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Guía de inicio rápido</h1>
 
@@ -60,5 +62,6 @@ print(&quot;Precision:&quot;, clf.score(X_te, y_te))
 <li>Consulta la <a href="../api/index.html">referencia de API</a>.</li>
 </ul>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/glossary.html
+++ b/docs/glossary.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Glosario</h1>
 
@@ -16,5 +18,6 @@
 <li><strong>Segmento</strong>: grupo de instancias que comparte características similares y una etiqueta predominante.</li>
 </ul>
 </div>
+  <script src="sidebar.js"></script>
 </body>
 </html>

--- a/docs/guides/architecture.html
+++ b/docs/guides/architecture.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Guía: Arquitectura interna</h1>
 
@@ -30,5 +32,6 @@
 
 <p>Este diseño modular facilita extender o reemplazar componentes sin alterar el resto del sistema.</p>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/guides/config.html
+++ b/docs/guides/config.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Guía: Configuración y parámetros</h1>
 
@@ -34,5 +36,6 @@ InsideForestClassifier(
 
 <p>Se puede utilizar <code>GridSearchCV</code> o <code>RandomizedSearchCV</code> para optimizar los parámetros. Revisa los <a href="../tutorials/pipeline.html">tutoriales</a> para ver un ejemplo.</p>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Guías de uso</h1>
 
@@ -15,5 +17,6 @@
 <li><a href="interpretation.html">Interpretación de resultados</a></li>
 </ul>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/guides/interpretation.html
+++ b/docs/guides/interpretation.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Guía: Interpretación de resultados</h1>
 
@@ -33,5 +35,6 @@ for desc in descriptions:
 
 <p>Puedes exportar los resultados a formatos como CSV o JSON y usar librerías de visualización (ej. <code>plotly</code>) para explorar interactivamente las regiones.</p>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,19 +7,7 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <nav id="sidebar">
-    <input type="text" id="search" placeholder="Buscar..." />
-    <ul id="nav-list">
-      <li><a href="index.html">Inicio</a></li>
-      <li><a href="getting-started/index.html">Guía rápida</a></li>
-      <li><a href="tutorials/index.html">Tutoriales</a></li>
-      <li><a href="guides/index.html">Guías de uso</a></li>
-      <li><a href="api/index.html">Referencia API</a></li>
-      <li><a href="faq.html">FAQ</a></li>
-      <li><a href="glossary.html">Glosario</a></li>
-      <li><a href="resources.html">Recursos</a></li>
-    </ul>
-  </nav>
+  <nav id="sidebar"></nav>
 
   <div class="main-content">
     <h1>InsideForest <span class="badge">v1.0</span></h1>
@@ -27,6 +15,10 @@
 
     <div class="doc-image">
       <img src="../data/inside_f1.jpeg" alt="Ejemplo InsideForest" />
+    </div>
+
+    <div class="doc-image">
+      <img src="../data/iris_plot.png" alt="Distribución Iris" />
     </div>
 
     <h2>Uso básico</h2>
@@ -62,7 +54,7 @@ PYTHONPATH=src pytest tests/test_basic.py::test_import_and_fit -q</code></pre>
     </ul>
 
     <h2>Experimentos &amp; Benchmarks</h2>
-    <p>Comparaciones de rendimiento y resultados están disponibles en el
+    <p>Consulta los <a href="benchmarks.html">resultados comparativos</a> y el
       <a href="paper.html">paper del proyecto</a>.</p>
 
     <h2>Acerca de</h2>

--- a/docs/license.html
+++ b/docs/license.html
@@ -6,10 +6,13 @@
 <link rel='stylesheet' href='style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Licencia</h1>
 
 <p>InsideForest se distribuye bajo la licencia MIT. Consulta el archivo <a href="../LICENSE">LICENSE</a> en la raíz del repositorio para conocer los detalles completos y los términos de uso.</p>
 </div>
+  <script src="sidebar.js"></script>
 </body>
 </html>

--- a/docs/paper.html
+++ b/docs/paper.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Paper técnico de InsideForest</h1>
 <p>Este documento resume el paper <em>InsideForest: un enfoque interpretativo para el clustering supervisado</em>, donde se describen los fundamentos teóricos y la arquitectura de la librería.</p>
@@ -27,5 +29,6 @@ print(segments[:3])
 
 <p>El documento completo, con demostraciones formales y resultados experimentales, está disponible en el archivo <code><a href="../README.paper.md">README.paper.md</a></code> del repositorio.</p>
 </div>
+  <script src="sidebar.js"></script>
 </body>
 </html>

--- a/docs/resources.html
+++ b/docs/resources.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Recursos externos</h1>
 <ul>
@@ -14,5 +16,6 @@
 <li><a href="https://youtu.be/XYZ123">Presentaciones y charlas</a></li>
 </ul>
 </div>
+  <script src="sidebar.js"></script>
 </body>
 </html>

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Roadmap</h1>
 
@@ -16,5 +18,6 @@
 <li>Traducciones adicionales de la documentación.</li>
 </ul>
 </div>
+  <script src="sidebar.js"></script>
 </body>
 </html>

--- a/docs/sidebar.js
+++ b/docs/sidebar.js
@@ -1,14 +1,51 @@
 function filterNav() {
-    const query = document.getElementById('search').value.toLowerCase();
-    document.querySelectorAll('#nav-list li').forEach(li => {
-        const text = li.textContent.toLowerCase();
-        li.style.display = text.includes(query) ? '' : 'none';
-    });
+  const query = document.getElementById('search').value.toLowerCase();
+  document.querySelectorAll('#nav-list li').forEach(li => {
+    const text = li.textContent.toLowerCase();
+    li.style.display = text.includes(query) ? '' : 'none';
+  });
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    const search = document.getElementById('search');
-    if (search) {
-        search.addEventListener('input', filterNav);
-    }
+  const sidebar = document.getElementById('sidebar');
+  if (!sidebar) return;
+
+  const parts = window.location.pathname.split('/');
+  const docsIndex = parts.lastIndexOf('docs');
+  let rel = '';
+  if (docsIndex !== -1) {
+    const depth = parts.length - docsIndex - 1;
+    for (let i = 0; i < depth; i++) rel += '../';
+  }
+
+  sidebar.innerHTML = `
+    <input type="text" id="search" placeholder="Buscar..." />
+    <ul id="nav-list">
+      <li class="collapsible">
+        <a href="#">InsideForest</a>
+        <ul class="nested">
+          <li><a href="${rel}index.html">Inicio</a></li>
+          <li><a href="${rel}getting-started/index.html">Guía rápida</a></li>
+          <li><a href="${rel}tutorials/index.html">Tutoriales</a></li>
+          <li><a href="${rel}guides/index.html">Guías de uso</a></li>
+          <li><a href="${rel}api/index.html">Referencia API</a></li>
+          <li><a href="${rel}benchmarks.html">Benchmarks</a></li>
+          <li><a href="${rel}faq.html">FAQ</a></li>
+          <li><a href="${rel}glossary.html">Glosario</a></li>
+          <li><a href="${rel}resources.html">Recursos</a></li>
+        </ul>
+      </li>
+    </ul>`;
+
+  const coll = sidebar.querySelector('.collapsible > a');
+  const nested = sidebar.querySelector('.nested');
+  coll.addEventListener('click', (e) => {
+    e.preventDefault();
+    nested.classList.toggle('open');
+  });
+
+  const search = document.getElementById('search');
+  if (search) {
+    search.addEventListener('input', filterNav);
+  }
 });

--- a/docs/style.css
+++ b/docs/style.css
@@ -15,7 +15,8 @@
   background-color: var(--background-color);
   color: var(--text-color);
   max-width: 900px;
-  margin-left: 270px;
+  flex: 1;
+  margin: 0 auto;
   padding: 2rem;
 }
 
@@ -84,13 +85,13 @@
 /* Layout for documentation with sidebar */
 body {
   margin: 0;
+  display: flex;
 }
 
 #sidebar {
-  position: fixed;
+  position: sticky;
   top: 0;
-  left: 0;
-  width: 250px;
+  flex: 0 0 250px;
   height: 100vh;
   background-color: var(--background-color);
   border-right: 1px solid var(--border-color);
@@ -123,4 +124,25 @@ body {
 
 #sidebar a:hover {
   color: var(--accent-color);
+}
+
+#sidebar .collapsible > a {
+  cursor: pointer;
+  font-weight: bold;
+}
+
+#sidebar .collapsible > a::after {
+  content: '\25BC';
+  float: right;
+}
+
+#sidebar .nested {
+  display: none;
+  list-style: none;
+  padding-left: 1rem;
+  margin: 0;
+}
+
+#sidebar .nested.open {
+  display: block;
 }

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Solución de problemas</h1>
 
@@ -26,5 +28,6 @@ pip install --upgrade pip setuptools
 <h2>Problemas durante el entrenamiento</h2>
 <p>Verifica que no existan valores nulos y que las etiquetas estén bien formadas. Si el problema persiste, abre un issue en el repositorio.</p>
 </div>
+  <script src="sidebar.js"></script>
 </body>
 </html>

--- a/docs/tutorials/classification.html
+++ b/docs/tutorials/classification.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Tutorial: Clasificación supervisada básica</h1>
 
@@ -58,5 +60,6 @@ print(&quot;Precisión:&quot;, clf.score(X_te, y_te))
 <li>Habilitar <code>rf_params</code> personalizados para controlar el bosque subyacente.</li>
 </ul>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/tutorials/index.html
+++ b/docs/tutorials/index.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Tutoriales</h1>
 
@@ -16,5 +18,6 @@
 <li><a href="persistence.html">Guardado y carga de modelos</a></li>
 </ul>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/tutorials/persistence.html
+++ b/docs/tutorials/persistence.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Tutorial: Guardado y carga de modelos</h1>
 
@@ -26,5 +28,6 @@ print(&quot;Modelo cargado, precisión:&quot;, loaded.score(X_te, y_te))
 
 <p>Guarda los artefactos generados por <code>InsideForest</code> junto a metadatos de la versión utilizada para asegurar reproducibilidad.</p>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/tutorials/pipeline.html
+++ b/docs/tutorials/pipeline.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Tutorial: Integración con pipelines de scikit-learn</h1>
 
@@ -35,5 +37,6 @@ print(&quot;Mejores parámetros:&quot;, grid.best_params_)
 
 <p>Este enfoque facilita el ajuste fino de hiperparámetros y la reproducibilidad de experimentos.</p>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>

--- a/docs/tutorials/regression.html
+++ b/docs/tutorials/regression.html
@@ -6,6 +6,8 @@
 <link rel='stylesheet' href='../style.css' />
 </head>
 <body>
+  <nav id="sidebar"></nav>
+
 <div class="main-content">
 <h1>Tutorial: Regresión supervisada</h1>
 
@@ -51,5 +53,6 @@ print(&quot;R2:&quot;, r2_score(y[:5], preds))
 <li>Ajusta <code>n_estimators</code> para equilibrar precisión y tiempo de entrenamiento.</li>
 </ul>
 </div>
+  <script src="../sidebar.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep sidebar navigation fixed and expandable for InsideForest methods
- center main content with responsive layout and improved styles
- add benchmark section with images and metrics

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7a39d268c832c9ee8698dc15da421