### PR TITLE
Move docs search to index page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,10 @@
 
   <div class="main-content">
     <h1>InsideForest <span class="badge">v1.0</span></h1>
+    <div id="search-container">
+      <input type="text" id="page-search" placeholder="Buscar en la biblioteca..." />
+      <ul id="search-results"></ul>
+    </div>
     <p>Bienvenido a la documentación de InsideForest. Utiliza el índice de la izquierda para navegar por las secciones.</p>
 
     <div class="doc-image">
@@ -67,6 +71,7 @@ PYTHONPATH=src pytest -q</code></pre>
   </div>
 
   <script src="sidebar.js"></script>
+  <script src="search.js"></script>
 </body>
 </html>
 

--- a/docs/search.js
+++ b/docs/search.js
@@ -1,0 +1,61 @@
+const PAGES = [
+  { url: 'faq.html', title: 'Preguntas frecuentes' },
+  { url: 'index.html', title: 'InsideForest v1.0' },
+  { url: 'license.html', title: 'Licencia' },
+  { url: 'benchmarks.html', title: 'Benchmarks' },
+  { url: 'troubleshooting.html', title: 'Solución de problemas' },
+  { url: 'roadmap.html', title: 'Roadmap' },
+  { url: 'resources.html', title: 'Recursos externos' },
+  { url: 'glossary.html', title: 'Glosario' },
+  { url: 'changelog.html', title: 'Notas de versión' },
+  { url: 'paper.html', title: 'Paper técnico de InsideForest' },
+  { url: 'examples/index.html', title: 'Casos de uso' },
+  { url: 'examples/marketing.html', title: 'Ejemplo: Segmentación de clientes' },
+  { url: 'api/index.html', title: 'Referencia de API' },
+  { url: 'guides/index.html', title: 'Guías de uso' },
+  { url: 'guides/architecture.html', title: 'Guía: Arquitectura interna' },
+  { url: 'guides/config.html', title: 'Guía: Configuración y parámetros' },
+  { url: 'guides/interpretation.html', title: 'Guía: Interpretación de resultados' },
+  { url: 'tutorials/index.html', title: 'Tutoriales' },
+  { url: 'tutorials/persistence.html', title: 'Tutorial: Guardado y carga de modelos' },
+  { url: 'tutorials/classification.html', title: 'Tutorial: Clasificación supervisada básica' },
+  { url: 'tutorials/pipeline.html', title: 'Tutorial: Integración con pipelines de scikit-learn' },
+  { url: 'tutorials/regression.html', title: 'Tutorial: Regresión supervisada' },
+  { url: 'development/index.html', title: 'Sección de desarrollo' },
+  { url: 'blog/index.html', title: 'Blog / Noticias' },
+  { url: 'contributing/index.html', title: 'Contribuir' },
+  { url: 'community/index.html', title: 'Comunidad' },
+  { url: 'getting-started/index.html', title: 'Guía de inicio rápido' },
+  { url: 'advanced/index.html', title: 'Recetas avanzadas' },
+  { url: 'advanced/scaling.html', title: 'Receta avanzada: Uso en conjuntos de datos masivos' },
+  { url: 'advanced/hyperparameter.html', title: 'Receta avanzada: Ajuste fino de hiperparámetros' }
+];
+
+function searchDocs(query) {
+  const results = document.getElementById('search-results');
+  results.innerHTML = '';
+  if (!query) return;
+  const q = query.toLowerCase();
+  PAGES.forEach(page => {
+    fetch(page.url)
+      .then(resp => resp.text())
+      .then(text => {
+        if (text.toLowerCase().includes(q)) {
+          const li = document.createElement('li');
+          const a = document.createElement('a');
+          a.href = page.url;
+          a.textContent = page.title;
+          li.appendChild(a);
+          results.appendChild(li);
+        }
+      })
+      .catch(err => console.error(err));
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const input = document.getElementById('page-search');
+  if (input) {
+    input.addEventListener('input', () => searchDocs(input.value));
+  }
+});

--- a/docs/sidebar.js
+++ b/docs/sidebar.js
@@ -1,11 +1,3 @@
-function filterNav() {
-  const query = document.getElementById('search').value.toLowerCase();
-  document.querySelectorAll('#nav-list li').forEach(li => {
-    const text = li.textContent.toLowerCase();
-    li.style.display = text.includes(query) ? '' : 'none';
-  });
-}
-
 document.addEventListener('DOMContentLoaded', () => {
   const sidebar = document.getElementById('sidebar');
   if (!sidebar) return;
@@ -19,7 +11,6 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   sidebar.innerHTML = `
-    <input type="text" id="search" placeholder="Buscar..." />
     <ul id="nav-list">
       <li class="collapsible">
         <a href="#">InsideForest</a>
@@ -44,8 +35,4 @@ document.addEventListener('DOMContentLoaded', () => {
     nested.classList.toggle('open');
   });
 
-  const search = document.getElementById('search');
-  if (search) {
-    search.addEventListener('input', filterNav);
-  }
 });

--- a/docs/style.css
+++ b/docs/style.css
@@ -99,14 +99,6 @@ body {
   overflow-y: auto;
 }
 
-#sidebar input {
-  width: 100%;
-  padding: 0.5rem;
-  margin-bottom: 1rem;
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
-}
-
 #sidebar ul {
   list-style: none;
   padding: 0;
@@ -145,4 +137,26 @@ body {
 
 #sidebar .nested.open {
   display: block;
+}
+
+/* Search box in main content */
+#search-container {
+  margin: 1rem 0;
+}
+
+#search-container input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+#search-results {
+  list-style: none;
+  padding: 0;
+  margin-top: 0.5rem;
+}
+
+#search-results li {
+  margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- Add full-library search box to documentation landing page
- Remove sidebar search and style new search area
- Implement client-side search across all docs pages

## Testing
- `PYTHONPATH=src pytest tests -q` *(29 passed, interrupted after completion)*

------
https://chatgpt.com/codex/tasks/task_e_68b7aa0ed4b4832cbc6ba94b2fff1d4a