### PR TITLE
Expose InsideForest page and highlight core methods

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -34,6 +34,13 @@ labels = clf.predict(X)</code></pre>
       Aprende cómo funciona en <a href="guides/architecture.html">Cómo funciona</a>.
     </p>
 
+    <h2>Métodos principales</h2>
+    <ul>
+      <li><code>fit(X, y)</code>: entrena el modelo con los datos proporcionados.</li>
+      <li><code>predict(X)</code>: genera etiquetas de clúster para nuevas observaciones.</li>
+      <li><code>plot_importances()</code>: visualiza la importancia de cada característica.</li>
+    </ul>
+
     <h2>Primeros pasos</h2>
     <p>Instala la librería y ejecuta una prueba básica:</p>
     <pre><code class="language-shell">pip install InsideForest

--- a/docs/sidebar.js
+++ b/docs/sidebar.js
@@ -21,28 +21,16 @@ document.addEventListener('DOMContentLoaded', () => {
   sidebar.innerHTML = `
     <input type="text" id="search" placeholder="Buscar..." />
     <ul id="nav-list">
-      <li class="collapsible">
-        <a href="#">InsideForest</a>
-        <ul class="nested">
-          <li><a href="${rel}index.html">Inicio</a></li>
-          <li><a href="${rel}getting-started/index.html">Guía rápida</a></li>
-          <li><a href="${rel}tutorials/index.html">Tutoriales</a></li>
-          <li><a href="${rel}guides/index.html">Guías de uso</a></li>
-          <li><a href="${rel}api/index.html">Referencia API</a></li>
-          <li><a href="${rel}benchmarks.html">Benchmarks</a></li>
-          <li><a href="${rel}faq.html">FAQ</a></li>
-          <li><a href="${rel}glossary.html">Glosario</a></li>
-          <li><a href="${rel}resources.html">Recursos</a></li>
-        </ul>
-      </li>
+      <li><a href="${rel}index.html">InsideForest</a></li>
+      <li><a href="${rel}getting-started/index.html">Guía rápida</a></li>
+      <li><a href="${rel}tutorials/index.html">Tutoriales</a></li>
+      <li><a href="${rel}guides/index.html">Guías de uso</a></li>
+      <li><a href="${rel}api/index.html">Referencia API</a></li>
+      <li><a href="${rel}benchmarks.html">Benchmarks</a></li>
+      <li><a href="${rel}faq.html">FAQ</a></li>
+      <li><a href="${rel}glossary.html">Glosario</a></li>
+      <li><a href="${rel}resources.html">Recursos</a></li>
     </ul>`;
-
-  const coll = sidebar.querySelector('.collapsible > a');
-  const nested = sidebar.querySelector('.nested');
-  coll.addEventListener('click', (e) => {
-    e.preventDefault();
-    nested.classList.toggle('open');
-  });
 
   const search = document.getElementById('search');
   if (search) {


### PR DESCRIPTION
## Summary
- Simplify sidebar structure so InsideForest appears alongside other sections
- Document key InsideForestClassifier methods including fit, predict and plot_importances

## Testing
- `PYTHONPATH=. pytest tests/test_models.py::test_get_knn_rows_success -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7aa73a0d4832ca8fe6317f2ac8ac8