### PR TITLE
Fix documentation front matter for Jekyll rendering

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -1,4 +1,3 @@
-
 ---
 layout: default
 title: API Reference

--- a/docs/api/index_es.html
+++ b/docs/api/index_es.html
@@ -1,4 +1,3 @@
-
 ---
 layout: default
 title: Referencia API

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -1,4 +1,3 @@
-
 ---
 layout: default
 title: Guides

--- a/docs/guides/index_es.html
+++ b/docs/guides/index_es.html
@@ -1,4 +1,3 @@
-
 ---
 layout: default
 title: Guías

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,3 @@
-
 ---
 layout: default
 title: InsideForest

--- a/docs/index_es.html
+++ b/docs/index_es.html
@@ -1,4 +1,3 @@
-
 ---
 layout: default
 title: InsideForest ES

--- a/docs/tutorials/index.html
+++ b/docs/tutorials/index.html
@@ -1,4 +1,3 @@
-
 ---
 layout: default
 title: Tutorials

--- a/docs/tutorials/index_es.html
+++ b/docs/tutorials/index_es.html
@@ -1,4 +1,3 @@
-
 ---
 layout: default
 title: Tutoriales


### PR DESCRIPTION
## Summary
- Remove leading blank lines from documentation index files so Jekyll parses the front matter and applies the theme correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7c5d377f4832cac4f8295b2540dce