### PR TITLE
docs: enable search and add metadata

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,6 @@
 title: InsideForest Documentation
-description: Official documentation for the InsideForest library
+description: InsideForest: supervised clustering with interpretable regions.
 remote_theme: just-the-docs/just-the-docs
+search_enabled: true
+sitemap: true
+keywords: InsideForest, clustering, interpretable, regions, trees

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,0 +1,6 @@
+{% if page.description or site.description %}
+<meta name="description" content="{{ page.description | default: site.description }}">
+{% endif %}
+{% if page.keywords or site.keywords %}
+<meta name="keywords" content="{{ page.keywords | default: site.keywords }}">
+{% endif %}

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Changelog
+description: Chronological list of InsideForest changes.
 nav_order: 92
 ---
 

--- a/docs/changelog_es.html
+++ b/docs/changelog_es.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Registro de Cambios
+description: Lista cronológica de cambios de InsideForest.
 nav_order: 92
 nav_exclude: true
 ---

--- a/docs/experiments_benchmarks.html
+++ b/docs/experiments_benchmarks.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Experiments and Benchmarks
+description: Experiments and benchmarks demonstrating InsideForest.
 nav_exclude: true
 ---
 

--- a/docs/experiments_benchmarks_es.html
+++ b/docs/experiments_benchmarks_es.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Experimentos y Benchmarks
+description: Experimentos y benchmarks que demuestran InsideForest.
 nav_exclude: true
 ---
 

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: FAQ
+description: Frequently asked questions about InsideForest usage.
 nav_order: 90
 ---
 

--- a/docs/faq_es.html
+++ b/docs/faq_es.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Preguntas Frecuentes
+description: Preguntas frecuentes sobre el uso de InsideForest.
 nav_order: 90
 nav_exclude: true
 ---

--- a/docs/how_it_works.html
+++ b/docs/how_it_works.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: How It Works
+description: Explanation of InsideForest's supervised clustering approach.
 parent: InsideForest
 nav_order: 0
 ---

--- a/docs/how_it_works_es.html
+++ b/docs/how_it_works_es.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Cómo Funciona
+description: Explicación del enfoque de clustering supervisado de InsideForest.
 parent: InsideForest
 nav_order: 0
 nav_exclude: true

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,6 +2,7 @@
 ---
 layout: default
 title: InsideForest
+description: InsideForest: supervised clustering with interpretable regions.
 nav_order: 1
 has_children: true
 ---

--- a/docs/index_es.html
+++ b/docs/index_es.html
@@ -2,6 +2,7 @@
 ---
 layout: default
 title: InsideForest ES
+description: InsideForest: clustering supervisado con regiones interpretables.
 nav_order: 1
 has_children: true
 nav_exclude: true

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Installation
+description: Install the InsideForest library and its dependencies.
 nav_order: 3
 ---
 

--- a/docs/installation_es.html
+++ b/docs/installation_es.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Instalación
+description: Instala la librería InsideForest y sus dependencias.
 nav_order: 3
 nav_exclude: true
 ---

--- a/docs/license.html
+++ b/docs/license.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: License
+description: License information for InsideForest.
 nav_order: 100
 ---
 

--- a/docs/license_es.html
+++ b/docs/license_es.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Licencia
+description: Información de la licencia de InsideForest.
 nav_order: 100
 nav_exclude: true
 ---

--- a/docs/performance_tips.html
+++ b/docs/performance_tips.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Performance Tips
+description: Tips to improve InsideForest performance.
 nav_order: 9
 ---
 

--- a/docs/performance_tips_es.html
+++ b/docs/performance_tips_es.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Consejos de Rendimiento
+description: Consejos para mejorar el rendimiento de InsideForest.
 nav_order: 9
 nav_exclude: true
 ---

--- a/docs/quick_api.html
+++ b/docs/quick_api.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Quick API
+description: Quick reference for using InsideForest's API.
 nav_order: 5
 ---
 

--- a/docs/quick_api_es.html
+++ b/docs/quick_api_es.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: API Rápida
+description: Referencia rápida para usar la API de InsideForest.
 nav_order: 5
 nav_exclude: true
 ---

--- a/docs/reproducibility.html
+++ b/docs/reproducibility.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Reproducibility
+description: Reproducibility guidelines for InsideForest experiments.
 nav_order: 4
 ---
 

--- a/docs/reproducibility_es.html
+++ b/docs/reproducibility_es.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Reproducibilidad
+description: Guía de reproducibilidad para los experimentos de InsideForest.
 nav_order: 4
 nav_exclude: true
 ---

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Roadmap
+description: Future development roadmap for InsideForest.
 nav_order: 91
 ---
 

--- a/docs/roadmap_es.html
+++ b/docs/roadmap_es.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Hoja de Ruta
+description: Hoja de ruta del desarrollo futuro de InsideForest.
 nav_order: 91
 nav_exclude: true
 ---


### PR DESCRIPTION
## Summary
- enable built-in search and sitemap for documentation
- add custom head include with description and keywords
- provide per-page meta descriptions across docs

## Testing
- `pytest` *(fails: KeyboardInterrupt)*
- `pytest tests/test_descrip.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7c5709b14832ca042ea3aad06f2f9