### PR TITLE
Add bilingual docs and API references

### DIFF
--- a/docs/api/clusterselector.html
+++ b/docs/api/clusterselector.html
@@ -8,5 +8,20 @@ nav_order: 6
 <link rel="stylesheet" href="../style.css">
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="clusterselector_es.html">ES</a></div>
-<h1>ClusterSelector</h1>
-<p>API reference for ClusterSelector.</p>
+<h1>MenuClusterSelector</h1>
+<h2>Signature</h2>
+<pre><code class="language-python">class MenuClusterSelector(...):
+    def __init__(self, w_nmi=1.0, w_v=1.0, lam_k=0.1, target_K=None, smoothing=1.0, max_passes=5, tol=1e-6, seed=42): ...
+</code></pre>
+<h2>Methods</h2>
+<ul>
+  <li><code>fit(records, y)</code>: estimate value distributions.</li>
+  <li><code>predict(records, n_clusters=None)</code>: assign values maximizing the objective.</li>
+</ul>
+<h2>Example</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import MenuClusterSelector
+sel = MenuClusterSelector().fit(X, y)
+labels = sel.predict(X)
+plt.scatter(X[:,0], X[:,1], c=labels)
+plt.show()</code></pre>

--- a/docs/api/clusterselector_es.html
+++ b/docs/api/clusterselector_es.html
@@ -9,5 +9,20 @@ nav_exclude: true
 <link rel="stylesheet" href="../style.css">
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="clusterselector.html">EN</a></div>
-<h1>ClusterSelector</h1>
-<p>Referencia API para ClusterSelector.</p>
+<h1>MenuClusterSelector</h1>
+<h2>Firma</h2>
+<pre><code class="language-python">class MenuClusterSelector(...):
+    def __init__(self, w_nmi=1.0, w_v=1.0, lam_k=0.1, target_K=None, smoothing=1.0, max_passes=5, tol=1e-6, seed=42): ...
+</code></pre>
+<h2>Métodos</h2>
+<ul>
+  <li><code>fit(records, y)</code>: estima distribuciones de valores.</li>
+  <li><code>predict(records, n_clusters=None)</code>: asigna valores maximizando el objetivo.</li>
+</ul>
+<h2>Ejemplo</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import MenuClusterSelector
+sel = MenuClusterSelector().fit(X, y)
+labels = sel.predict(X)
+plt.scatter(X[:,0], X[:,1], c=labels)
+plt.show()</code></pre>

--- a/docs/api/insideforestclassifier.html
+++ b/docs/api/insideforestclassifier.html
@@ -9,4 +9,21 @@ nav_order: 1
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="insideforestclassifier_es.html">ES</a></div>
 <h1>InsideForestClassifier</h1>
-<p>API reference for InsideForestClassifier.</p>
+<h2>Signature</h2>
+<pre><code class="language-python">class InsideForestClassifier(...):
+    def __init__(self, n_estimators=200, max_depth=None, random_state=None, ...): ...
+</code></pre>
+<h2>Methods</h2>
+<ul>
+  <li><code>fit(X, y)</code>: train and extract regions.</li>
+  <li><code>predict(X)</code>: assign classes.</li>
+  <li><code>score(X, y)</code>: evaluation.</li>
+  <li><code>save(path)</code> / <code>load(path)</code>: persistence.</li>
+</ul>
+<h2>Example</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import InsideForestClassifier
+clf = InsideForestClassifier(random_state=0).fit(X, y)
+yhat = clf.predict(X)
+plt.scatter(y, yhat)
+plt.show()</code></pre>

--- a/docs/api/insideforestclassifier_es.html
+++ b/docs/api/insideforestclassifier_es.html
@@ -10,4 +10,21 @@ nav_exclude: true
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="insideforestclassifier.html">EN</a></div>
 <h1>InsideForestClassifier</h1>
-<p>Referencia API para InsideForestClassifier.</p>
+<h2>Firma</h2>
+<pre><code class="language-python">class InsideForestClassifier(...):
+    def __init__(self, n_estimators=200, max_depth=None, random_state=None, ...): ...
+</code></pre>
+<h2>Métodos</h2>
+<ul>
+  <li><code>fit(X, y)</code>: entrena y extrae regiones.</li>
+  <li><code>predict(X)</code>: asigna clases.</li>
+  <li><code>score(X, y)</code>: evaluación.</li>
+  <li><code>save(path)</code> / <code>load(path)</code>: persistencia.</li>
+</ul>
+<h2>Ejemplo</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import InsideForestClassifier
+clf = InsideForestClassifier(random_state=0).fit(X, y)
+yhat = clf.predict(X)
+plt.scatter(y, yhat)
+plt.show()</code></pre>

--- a/docs/api/insideforestregressor.html
+++ b/docs/api/insideforestregressor.html
@@ -9,4 +9,21 @@ nav_order: 2
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="insideforestregressor_es.html">ES</a></div>
 <h1>InsideForestRegressor</h1>
-<p>API reference for InsideForestRegressor.</p>
+<h2>Signature</h2>
+<pre><code class="language-python">class InsideForestRegressor(...):
+    def __init__(self, n_estimators=200, max_depth=None, random_state=None, ...): ...
+</code></pre>
+<h2>Methods</h2>
+<ul>
+  <li><code>fit(X, y)</code>: train and extract regions.</li>
+  <li><code>predict(X)</code>: predict values.</li>
+  <li><code>score(X, y)</code>: evaluation.</li>
+  <li><code>save(path)</code> / <code>load(path)</code>: persistence.</li>
+</ul>
+<h2>Example</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import InsideForestRegressor
+reg = InsideForestRegressor(random_state=0).fit(X, y)
+yhat = reg.predict(X)
+plt.scatter(y, yhat)
+plt.show()</code></pre>

--- a/docs/api/insideforestregressor_es.html
+++ b/docs/api/insideforestregressor_es.html
@@ -10,4 +10,21 @@ nav_exclude: true
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="insideforestregressor.html">EN</a></div>
 <h1>InsideForestRegressor</h1>
-<p>Referencia API para InsideForestRegressor.</p>
+<h2>Firma</h2>
+<pre><code class="language-python">class InsideForestRegressor(...):
+    def __init__(self, n_estimators=200, max_depth=None, random_state=None, ...): ...
+</code></pre>
+<h2>Métodos</h2>
+<ul>
+  <li><code>fit(X, y)</code>: entrena y extrae regiones.</li>
+  <li><code>predict(X)</code>: predice valores.</li>
+  <li><code>score(X, y)</code>: evaluación.</li>
+  <li><code>save(path)</code> / <code>load(path)</code>: persistencia.</li>
+</ul>
+<h2>Ejemplo</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import InsideForestRegressor
+reg = InsideForestRegressor(random_state=0).fit(X, y)
+yhat = reg.predict(X)
+plt.scatter(y, yhat)
+plt.show()</code></pre>

--- a/docs/api/labels.html
+++ b/docs/api/labels.html
@@ -9,4 +9,19 @@ nav_order: 4
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="labels_es.html">ES</a></div>
 <h1>Labels</h1>
-<p>API reference for Labels.</p>
+<h2>Signature</h2>
+<pre><code class="language-python">class Labels:
+    def __init__(self): ...
+</code></pre>
+<h2>Methods</h2>
+<ul>
+  <li><code>round_values(values)</code>: variance-aware rounding.</li>
+  <li><code>get_intervals(interval_df)</code>: describe intervals.</li>
+</ul>
+<h2>Example</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import Labels
+lab = Labels()
+intervals = lab.get_intervals(df)
+plt.plot(intervals)
+plt.show()</code></pre>

--- a/docs/api/labels_es.html
+++ b/docs/api/labels_es.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Etiquetas
+title: Labels
 parent: InsideForest
 nav_order: 4
 nav_exclude: true
@@ -9,5 +9,20 @@ nav_exclude: true
 <link rel="stylesheet" href="../style.css">
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="labels.html">EN</a></div>
-<h1>Etiquetas</h1>
-<p>Referencia API para Etiquetas.</p>
+<h1>Labels</h1>
+<h2>Firma</h2>
+<pre><code class="language-python">class Labels:
+    def __init__(self): ...
+</code></pre>
+<h2>Métodos</h2>
+<ul>
+  <li><code>round_values(values)</code>: redondeo según la varianza.</li>
+  <li><code>get_intervals(interval_df)</code>: describe intervalos.</li>
+</ul>
+<h2>Ejemplo</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import Labels
+lab = Labels()
+intervalos = lab.get_intervals(df)
+plt.plot(intervalos)
+plt.show()</code></pre>

--- a/docs/api/metadata.html
+++ b/docs/api/metadata.html
@@ -2,11 +2,24 @@
 layout: default
 title: Metadata
 parent: InsideForest
-nav_order: 8
+nav_order: 7
 ---
 
 <link rel="stylesheet" href="../style.css">
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="metadata_es.html">ES</a></div>
-<h1>Metadata</h1>
-<p>API reference for Metadata.</p>
+<h1>MetaExtractor</h1>
+<h2>Signature</h2>
+<pre><code class="language-python">class MetaExtractor(metadata_df, var_obj, user_synonyms=None): ...
+</code></pre>
+<h2>Methods</h2>
+<ul>
+  <li><code>extract(df_QW, profile=Profile.ESSENTIAL)</code>: subset metadata for rule tokens.</li>
+</ul>
+<h2>Example</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import MetaExtractor, Profile
+mx = MetaExtractor(metadata_df, var_obj='target')
+mini = mx.extract(df_QW, profile=Profile.ESSENTIAL)
+plt.bar(mini.columns, mini.nunique())
+plt.show()</code></pre>

--- a/docs/api/metadata_es.html
+++ b/docs/api/metadata_es.html
@@ -1,13 +1,26 @@
 ---
 layout: default
-title: Metadatos
+title: Metadata
 parent: InsideForest
-nav_order: 8
+nav_order: 7
 nav_exclude: true
 ---
 
 <link rel="stylesheet" href="../style.css">
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="metadata.html">EN</a></div>
-<h1>Metadatos</h1>
-<p>Referencia API para Metadatos.</p>
+<h1>MetaExtractor</h1>
+<h2>Firma</h2>
+<pre><code class="language-python">class MetaExtractor(metadata_df, var_obj, user_synonyms=None): ...
+</code></pre>
+<h2>Métodos</h2>
+<ul>
+  <li><code>extract(df_QW, profile=Profile.ESSENTIAL)</code>: extrae metadatos para los tokens de reglas.</li>
+</ul>
+<h2>Ejemplo</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import MetaExtractor, Profile
+mx = MetaExtractor(metadata_df, var_obj='target')
+mini = mx.extract(df_QW, profile=Profile.ESSENTIAL)
+plt.bar(mini.columns, mini.nunique())
+plt.show()</code></pre>

--- a/docs/api/models.html
+++ b/docs/api/models.html
@@ -2,11 +2,27 @@
 layout: default
 title: Models
 parent: InsideForest
-nav_order: 5
+nav_order: 6
 ---
 
 <link rel="stylesheet" href="../style.css">
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="models_es.html">ES</a></div>
 <h1>Models</h1>
-<p>API reference for Models.</p>
+<h2>Signature</h2>
+<pre><code class="language-python">class Models:
+    ...
+</code></pre>
+<h2>Methods</h2>
+<ul>
+  <li><code>get_knn_rows(df, target_col)</code>: split rows based on KNN errors.</li>
+  <li><code>get_cvRF(X_train, y_train, param_grid)</code>: grid-search a RandomForest.</li>
+</ul>
+<h2>Example</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import Models
+md = Models()
+scores = [0.8, 0.85]
+plt.plot(scores)
+plt.show()
+# md.get_cvRF(X_train, y_train, {"n_estimators": [100]})</code></pre>

--- a/docs/api/models_es.html
+++ b/docs/api/models_es.html
@@ -1,13 +1,29 @@
 ---
 layout: default
-title: Modelos
+title: Models
 parent: InsideForest
-nav_order: 5
+nav_order: 6
 nav_exclude: true
 ---
 
 <link rel="stylesheet" href="../style.css">
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="models.html">EN</a></div>
-<h1>Modelos</h1>
-<p>Referencia API para Modelos.</p>
+<h1>Models</h1>
+<h2>Firma</h2>
+<pre><code class="language-python">class Models:
+    ...
+</code></pre>
+<h2>Métodos</h2>
+<ul>
+  <li><code>get_knn_rows(df, target_col)</code>: separa filas según errores de KNN.</li>
+  <li><code>get_cvRF(X_train, y_train, param_grid)</code>: búsqueda en grilla para RandomForest.</li>
+</ul>
+<h2>Ejemplo</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import Models
+md = Models()
+puntajes = [0.8, 0.85]
+plt.plot(puntajes)
+plt.show()
+# md.get_cvRF(X_train, y_train, {"n_estimators": [100]})</code></pre>

--- a/docs/api/regions.html
+++ b/docs/api/regions.html
@@ -9,4 +9,19 @@ nav_order: 3
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="regions_es.html">ES</a></div>
 <h1>Regions</h1>
-<p>API reference for Regions.</p>
+<h2>Signature</h2>
+<pre><code class="language-python">class Regions:
+    def __init__(self): ...
+</code></pre>
+<h2>Methods</h2>
+<ul>
+  <li><code>search_original_tree(df_clusterizado, separacion_dim)</code>: match clustered data to original splits.</li>
+  <li><code>mean_distance_ndim(df_sep_dm_agg)</code>: compute average bounds per dimension.</li>
+</ul>
+<h2>Example</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import Regions
+reg = Regions()
+bounds = reg.mean_distance_ndim(df_sep_dm_agg)
+plt.bar(range(len(bounds)), bounds)
+plt.show()</code></pre>

--- a/docs/api/regions_es.html
+++ b/docs/api/regions_es.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Regiones
+title: Regions
 parent: InsideForest
 nav_order: 3
 nav_exclude: true
@@ -9,5 +9,20 @@ nav_exclude: true
 <link rel="stylesheet" href="../style.css">
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="regions.html">EN</a></div>
-<h1>Regiones</h1>
-<p>Referencia API para Regiones.</p>
+<h1>Regions</h1>
+<h2>Firma</h2>
+<pre><code class="language-python">class Regions:
+    def __init__(self): ...
+</code></pre>
+<h2>Métodos</h2>
+<ul>
+  <li><code>search_original_tree(df_clusterizado, separacion_dim)</code>: empareja datos clusterizados con sus divisiones originales.</li>
+  <li><code>mean_distance_ndim(df_sep_dm_agg)</code>: calcula promedios por dimensión.</li>
+</ul>
+<h2>Ejemplo</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import Regions
+reg = Regions()
+bounds = reg.mean_distance_ndim(df_sep_dm_agg)
+plt.bar(range(len(bounds)), bounds)
+plt.show()</code></pre>

--- a/docs/api/trees.html
+++ b/docs/api/trees.html
@@ -2,11 +2,27 @@
 layout: default
 title: Trees
 parent: InsideForest
-nav_order: 7
+nav_order: 5
 ---
 
 <link rel="stylesheet" href="../style.css">
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="trees_es.html">ES</a></div>
 <h1>Trees</h1>
-<p>API reference for Trees.</p>
+<h2>Signature</h2>
+<pre><code class="language-python">class Trees(lang='python', n_sample_multiplier=2, ef_sample_multiplier=3, percentil=95, low_frac=0.05):
+    ...
+</code></pre>
+<h2>Methods</h2>
+<ul>
+  <li><code>transform_tree_structure(tree_str)</code>: convert Spark trees to scikit-learn style.</li>
+  <li><code>get_rangos(regr, data1)</code>: extract rules and importances.</li>
+</ul>
+<h2>Example</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import Trees
+tr = Trees()
+importances = [0.2, 0.5]
+plt.bar(range(len(importances)), importances)
+plt.show()
+# tr.get_rangos(model, data)</code></pre>

--- a/docs/api/trees_es.html
+++ b/docs/api/trees_es.html
@@ -1,13 +1,29 @@
 ---
 layout: default
-title: Árboles
+title: Trees
 parent: InsideForest
-nav_order: 7
+nav_order: 5
 nav_exclude: true
 ---
 
 <link rel="stylesheet" href="../style.css">
 <script src="../lang.js"></script>
 <div class="lang-switch"><a href="trees.html">EN</a></div>
-<h1>Árboles</h1>
-<p>Referencia API para Árboles.</p>
+<h1>Trees</h1>
+<h2>Firma</h2>
+<pre><code class="language-python">class Trees(lang='python', n_sample_multiplier=2, ef_sample_multiplier=3, percentil=95, low_frac=0.05):
+    ...
+</code></pre>
+<h2>Métodos</h2>
+<ul>
+  <li><code>transform_tree_structure(tree_str)</code>: convierte árboles de Spark al estilo scikit-learn.</li>
+  <li><code>get_rangos(regr, data1)</code>: extrae reglas e importancias.</li>
+</ul>
+<h2>Ejemplo</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import Trees
+tr = Trees()
+importancias = [0.2, 0.5]
+plt.bar(range(len(importancias)), importancias)
+plt.show()
+# tr.get_rangos(modelo, datos)</code></pre>

--- a/docs/experiments_benchmarks.html
+++ b/docs/experiments_benchmarks.html
@@ -9,4 +9,14 @@ nav_exclude: true
 <script src="lang.js"></script>
 <div class="lang-switch"><a href="experiments_benchmarks_es.html">ES</a></div>
 <h1>Experiments and Benchmarks</h1>
-<p>Summary of experiments and benchmarks.</p>
+<p>Summary of datasets and metrics.</p>
+<ul>
+  <li>UCI Adult – accuracy, F1.</li>
+  <li>Boston Housing – RMSE.</li>
+</ul>
+<h2>Example Plot</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+datasets = ["Adult", "Boston"]
+scores = [0.85, 3.2]
+plt.bar(datasets, scores)
+plt.show()</code></pre>

--- a/docs/experiments_benchmarks_es.html
+++ b/docs/experiments_benchmarks_es.html
@@ -9,4 +9,14 @@ nav_exclude: true
 <script src="lang.js"></script>
 <div class="lang-switch"><a href="experiments_benchmarks.html">EN</a></div>
 <h1>Experimentos y Benchmarks</h1>
-<p>Resumen de experimentos y benchmarks.</p>
+<p>Resumen de datasets y métricas.</p>
+<ul>
+  <li>UCI Adult – accuracy, F1.</li>
+  <li>Boston Housing – RMSE.</li>
+</ul>
+<h2>Ejemplo de Gráfico</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+datasets = ["Adult", "Boston"]
+scores = [0.85, 3.2]
+plt.bar(datasets, scores)
+plt.show()</code></pre>

--- a/docs/how_it_works.html
+++ b/docs/how_it_works.html
@@ -10,4 +10,5 @@ nav_order: 0
 <script src="lang.js"></script>
 <div class="lang-switch"><a href="how_it_works_es.html">ES</a></div>
 <h1>How It Works</h1>
-<p>Explanation of the InsideForest workflow.</p>
+<pre>Forest → Rules → Regions → Labels</pre>
+<p>A random forest generates rules, rules define regions, and regions receive labels.</p>

--- a/docs/how_it_works_es.html
+++ b/docs/how_it_works_es.html
@@ -11,4 +11,5 @@ nav_exclude: true
 <script src="lang.js"></script>
 <div class="lang-switch"><a href="how_it_works.html">EN</a></div>
 <h1>Cómo Funciona</h1>
-<p>Explicación del flujo de trabajo de InsideForest.</p>
+<pre>Bosque → Reglas → Regiones → Etiquetas</pre>
+<p>Un bosque aleatorio genera reglas, las reglas definen regiones y las regiones reciben etiquetas.</p>

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -9,4 +9,10 @@ nav_order: 3
 <script src="lang.js"></script>
 <div class="lang-switch"><a href="installation_es.html">ES</a></div>
 <h1>Installation</h1>
-<p>Instructions for installing InsideForest.</p>
+<p>Install InsideForest from PyPI or in development mode.</p>
+<h2>PyPI</h2>
+<pre><code class="language-bash">pip install insideforest</code></pre>
+<h2>Development</h2>
+<pre><code class="language-bash">git clone https://github.com/owner/InsideForest.git
+cd InsideForest
+pip install -e .[dev]</code></pre>

--- a/docs/installation_es.html
+++ b/docs/installation_es.html
@@ -10,4 +10,10 @@ nav_exclude: true
 <script src="lang.js"></script>
 <div class="lang-switch"><a href="installation.html">EN</a></div>
 <h1>Instalación</h1>
-<p>Instrucciones para instalar InsideForest.</p>
+<p>Instala InsideForest desde PyPI o en modo desarrollo.</p>
+<h2>PyPI</h2>
+<pre><code class="language-bash">pip install insideforest</code></pre>
+<h2>Desarrollo</h2>
+<pre><code class="language-bash">git clone https://github.com/owner/InsideForest.git
+cd InsideForest
+pip install -e .[dev]</code></pre>

--- a/docs/performance_tips.html
+++ b/docs/performance_tips.html
@@ -9,4 +9,8 @@ nav_order: 9
 <script src="lang.js"></script>
 <div class="lang-switch"><a href="performance_tips_es.html">ES</a></div>
 <h1>Performance Tips</h1>
-<p>Tips to optimize performance.</p>
+<ul>
+  <li><code>n_estimators</code>: fewer trees speed up training.</li>
+  <li><code>n_jobs</code>: use parallelism for heavy tree extraction.</li>
+  <li>Reduce memory by lowering <code>max_depth</code> or sampling data.</li>
+</ul>

--- a/docs/performance_tips_es.html
+++ b/docs/performance_tips_es.html
@@ -10,4 +10,8 @@ nav_exclude: true
 <script src="lang.js"></script>
 <div class="lang-switch"><a href="performance_tips.html">EN</a></div>
 <h1>Consejos de Rendimiento</h1>
-<p>Consejos para optimizar el rendimiento.</p>
+<ul>
+  <li><code>n_estimators</code>: menos árboles aceleran el entrenamiento.</li>
+  <li><code>n_jobs</code>: usa paralelismo para extraer árboles pesados.</li>
+  <li>Reduce memoria disminuyendo <code>max_depth</code> o muestreando datos.</li>
+</ul>

--- a/docs/quick_api.html
+++ b/docs/quick_api.html
@@ -9,4 +9,21 @@ nav_order: 5
 <script src="lang.js"></script>
 <div class="lang-switch"><a href="quick_api_es.html">ES</a></div>
 <h1>Quick API</h1>
-<p>Examples of quick API usage.</p>
+<h2>Classifier</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import InsideForestClassifier
+clf = InsideForestClassifier(random_state=0).fit(X, y)
+y_pred = clf.predict(X)
+plt.scatter(y, y_pred)
+plt.show()
+clf.save("clf.joblib")
+clf2 = InsideForestClassifier.load("clf.joblib")</code></pre>
+<h2>Regressor</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import InsideForestRegressor
+regr = InsideForestRegressor(random_state=0).fit(X, y)
+y_pred = regr.predict(X)
+plt.scatter(y, y_pred)
+plt.show()
+regr.save("reg.joblib")
+regr2 = InsideForestRegressor.load("reg.joblib")</code></pre>

--- a/docs/quick_api_es.html
+++ b/docs/quick_api_es.html
@@ -10,4 +10,21 @@ nav_exclude: true
 <script src="lang.js"></script>
 <div class="lang-switch"><a href="quick_api.html">EN</a></div>
 <h1>API Rápida</h1>
-<p>Ejemplos de uso rápido de la API.</p>
+<h2>Clasificador</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import InsideForestClassifier
+clf = InsideForestClassifier(random_state=0).fit(X, y)
+y_pred = clf.predict(X)
+plt.scatter(y, y_pred)
+plt.show()
+clf.save("clf.joblib")
+clf2 = InsideForestClassifier.load("clf.joblib")</code></pre>
+<h2>Regresor</h2>
+<pre><code class="language-python">import matplotlib.pyplot as plt
+from InsideForest import InsideForestRegressor
+regr = InsideForestRegressor(random_state=0).fit(X, y)
+y_pred = regr.predict(X)
+plt.scatter(y, y_pred)
+plt.show()
+regr.save("reg.joblib")
+regr2 = InsideForestRegressor.load("reg.joblib")</code></pre>

--- a/docs/reproducibility.html
+++ b/docs/reproducibility.html
@@ -9,4 +9,12 @@ nav_order: 4
 <script src="lang.js"></script>
 <div class="lang-switch"><a href="reproducibility_es.html">ES</a></div>
 <h1>Reproducibility</h1>
-<p>Guidelines for reproducible experiments.</p>
+<ul>
+  <li>Set <code>random_state</code> for deterministic results.</li>
+  <li>Record package versions including <code>insideforest</code>.</li>
+  <li>Seed Python and NumPy RNGs.</li>
+</ul>
+<pre><code class="language-python">import random, numpy as np
+from InsideForest import InsideForestClassifier
+random.seed(0); np.random.seed(0)
+clf = InsideForestClassifier(random_state=0)</code></pre>

--- a/docs/reproducibility_es.html
+++ b/docs/reproducibility_es.html
@@ -10,4 +10,12 @@ nav_exclude: true
 <script src="lang.js"></script>
 <div class="lang-switch"><a href="reproducibility.html">EN</a></div>
 <h1>Reproducibilidad</h1>
-<p>Guías para experimentos reproducibles.</p>
+<ul>
+  <li>Fija <code>random_state</code> para resultados deterministas.</li>
+  <li>Registra las versiones de paquetes incluyendo <code>insideforest</code>.</li>
+  <li>Semilla los RNG de Python y NumPy.</li>
+</ul>
+<pre><code class="language-python">import random, numpy as np
+from InsideForest import InsideForestClassifier
+random.seed(0); np.random.seed(0)
+clf = InsideForestClassifier(random_state=0)</code></pre>


### PR DESCRIPTION
## Summary
- Add matplotlib plot examples to quick start, experiments, and all core API docs
- Expand benchmark page with sample metric visualization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7cb3cb3c0832cbf900825381005ae