### PR TITLE
Fix Jekyll config YAML parsing error

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: InsideForest Documentation
-description: InsideForest: supervised clustering with interpretable regions.
+description: "InsideForest: supervised clustering with interpretable regions."
 remote_theme: just-the-docs/just-the-docs
 search_enabled: true
 sitemap: true


### PR DESCRIPTION
## Summary
- quote colon-containing description in `docs/_config.yml` to satisfy YAML parser

## Testing
- `pytest` (interrupted after 29 passed tests due to long runtime)

------
https://chatgpt.com/codex/tasks/task_e_68b7da63bac8832c8249adc740d8a465