### PR TITLE
Add copy button to documentation code blocks

### DIFF
--- a/docs/lang.js
+++ b/docs/lang.js
@@ -1,3 +1,29 @@
 document.addEventListener('DOMContentLoaded', function() {
   console.log('Language switcher ready');
+
+  // Add copy buttons to all code blocks
+  document.querySelectorAll('pre').forEach(pre => {
+    const code = pre.querySelector('code');
+    if (!code) return;
+
+    // Create the copy button
+    const button = document.createElement('button');
+    button.className = 'copy-button';
+    button.type = 'button';
+    button.textContent = 'Copy';
+
+    // Copy code to clipboard on click
+    button.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(code.innerText);
+        button.textContent = 'Copied!';
+        setTimeout(() => (button.textContent = 'Copy'), 2000);
+      } catch (err) {
+        console.error('Failed to copy', err);
+      }
+    });
+
+    pre.style.position = 'relative';
+    pre.appendChild(button);
+  });
 });

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,3 +1,17 @@
 .lang-switch {
   text-align: right;
 }
+
+/* Copy button for code blocks */
+pre {
+  position: relative;
+}
+
+.copy-button {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  padding: 2px 6px;
+  font-size: 0.8em;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- inject copy buttons into all documentation code blocks
- style copy button for top-right placement over code samples

## Testing
- `pytest` *(fails: KeyboardInterrupt after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_68b8eaf52b4c832c9720392f637fcca7