### PR TITLE
docs: add example use cases

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,3 +11,10 @@ has_children: true
 <div class="lang-switch"><a href="index_es.html">ES</a></div>
 <h1>InsideForest</h1>
 <p>Clustering supervisado con regiones interpretables.</p>
+<h2>Example use cases</h2>
+<ul>
+  <li>Analyze customer behavior to identify profitable segments.</li>
+  <li>Classify patients by medical history and symptoms.</li>
+  <li>Evaluate marketing channels using website traffic.</li>
+  <li>Build more accurate image-recognition systems.</li>
+</ul>


### PR DESCRIPTION
## Summary
- add "Example use cases" section to docs landing page

## Testing
- `pytest -q` *(interrupted after showing 29 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b998916880832cbacdef852e34075d