### PR TITLE
docs: describe FAST options for better performance

### DIFF
--- a/docs/performance_tips.html
+++ b/docs/performance_tips.html
@@ -14,3 +14,22 @@ nav_order: 9
   <li><code>n_jobs</code>: use parallelism for heavy tree extraction.</li>
   <li>Reduce memory by lowering <code>max_depth</code> or sampling data.</li>
 </ul>
+
+<h2>FAST options</h2>
+<h3><code>auto_fast</code></h3>
+<p>Automatically chooses faster training parameters based on dataset size.</p>
+<pre><code class="language-python">clf = InsideForestClassifier(auto_fast=True).fit(X, y)</code></pre>
+
+<h3><code>auto_feature_reduce</code></h3>
+<p>Reduces the number of features before training. Useful when there are many columns.</p>
+<pre><code class="language-python">clf = InsideForestClassifier(auto_feature_reduce=True).fit(X, y)</code></pre>
+
+<h3><code>explicit_k_features</code></h3>
+<p>Locks the number of retained features when <code>auto_feature_reduce</code> is enabled.</p>
+<pre><code class="language-python">clf = InsideForestClassifier(auto_feature_reduce=True,
+                             explicit_k_features=20).fit(X, y)</code></pre>
+
+<h3><code>fast_overrides</code></h3>
+<p>Overrides parts of the automatic FAST preset.</p>
+<pre><code class="language-python">clf = InsideForestClassifier(auto_fast=True,
+                             fast_overrides={"divide": 3}).fit(X, y)</code></pre>

--- a/docs/performance_tips_es.html
+++ b/docs/performance_tips_es.html
@@ -15,3 +15,22 @@ nav_exclude: true
   <li><code>n_jobs</code>: usa paralelismo para extraer árboles pesados.</li>
   <li>Reduce memoria disminuyendo <code>max_depth</code> o muestreando datos.</li>
 </ul>
+
+<h2>Opciones FAST</h2>
+<h3><code>auto_fast</code></h3>
+<p>Selecciona automáticamente parámetros de entrenamiento más rápidos según el tamaño del conjunto de datos.</p>
+<pre><code class="language-python">clf = InsideForestClassifier(auto_fast=True).fit(X, y)</code></pre>
+
+<h3><code>auto_feature_reduce</code></h3>
+<p>Reduce la cantidad de características antes del entrenamiento. Útil cuando hay muchas columnas.</p>
+<pre><code class="language-python">clf = InsideForestClassifier(auto_feature_reduce=True).fit(X, y)</code></pre>
+
+<h3><code>explicit_k_features</code></h3>
+<p>Fija el número de características conservadas cuando <code>auto_feature_reduce</code> está activado.</p>
+<pre><code class="language-python">clf = InsideForestClassifier(auto_feature_reduce=True,
+                             explicit_k_features=20).fit(X, y)</code></pre>
+
+<h3><code>fast_overrides</code></h3>
+<p>Ajusta parte del preset automático FAST.</p>
+<pre><code class="language-python">clf = InsideForestClassifier(auto_fast=True,
+                             fast_overrides={"divide": 3}).fit(X, y)</code></pre>


### PR DESCRIPTION
## Summary
- expand performance tips docs with FAST options (`auto_fast`, `auto_feature_reduce`, `explicit_k_features`, `fast_overrides`)
- add Spanish translation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b998a0706c832c91e289c2b8dba2ca