### PR TITLE
Add optional cluster balancing

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -71,19 +71,6 @@ in_f = InsideForestClassifier(
 
 in_f.fit(X_train, y_train)
 pred_labels = in_f.predict(X_rest)  # etiquetas de cluster para los datos restantes
-etiquetas_entrenamiento = in_f.labels_  # etiquetas para el subconjunto de entrenamiento
-```
-
-Activa un balanceo de clústeres para problemas multiclase con
-`balance_clusters=True`. Esto entrena el bosque aleatorio con
-`class_weight='balanced'` y cambia el método de consolidación a
-``"menu"`` para distribuir mejor los clústeres entre clases:
-
-```python
-in_f = InsideForestClassifier(balance_clusters=True)
-in_f.fit(X_train, y_train)
-```
-
 ### Presets FAST y reducción de características
 
 InsideForest puede elegir automáticamente parámetros de entrenamiento más

--- a/README.es.md
+++ b/README.es.md
@@ -74,6 +74,16 @@ pred_labels = in_f.predict(X_rest)  # etiquetas de cluster para los datos restan
 etiquetas_entrenamiento = in_f.labels_  # etiquetas para el subconjunto de entrenamiento
 ```
 
+Activa un balanceo de clústeres para problemas multiclase con
+`balance_clusters=True`. Esto entrena el bosque aleatorio con
+`class_weight='balanced'` y cambia el método de consolidación a
+``"menu"`` para distribuir mejor los clústeres entre clases:
+
+```python
+in_f = InsideForestClassifier(balance_clusters=True)
+in_f.fit(X_train, y_train)
+```
+
 ### Presets FAST y reducción de características
 
 InsideForest puede elegir automáticamente parámetros de entrenamiento más

--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ pred_labels = in_f.predict(X_rest)  # cluster labels for the remaining data
 training_labels = in_f.labels_  # labels for the training subset
 ```
 
+Enable balanced clustering for multi-class problems by setting
+`balance_clusters=True`. This trains the underlying random forest with
+`class_weight='balanced'` and switches the consolidation method to
+``"menu"`` to better distribute clusters across classes:
+
+```python
+in_f = InsideForestClassifier(balance_clusters=True)
+in_f.fit(X_train, y_train)
+```
+
 ### FAST presets and feature reduction
 
 InsideForest can automatically pick faster training parameters and reduce

--- a/README.md
+++ b/README.md
@@ -87,19 +87,6 @@ in_f = InsideForestClassifier(
 
 in_f.fit(X_train, y_train)
 pred_labels = in_f.predict(X_rest)  # cluster labels for the remaining data
-training_labels = in_f.labels_  # labels for the training subset
-```
-
-Enable balanced clustering for multi-class problems by setting
-`balance_clusters=True`. This trains the underlying random forest with
-`class_weight='balanced'` and switches the consolidation method to
-``"menu"`` to better distribute clusters across classes:
-
-```python
-in_f = InsideForestClassifier(balance_clusters=True)
-in_f.fit(X_train, y_train)
-```
-
 ### FAST presets and feature reduction
 
 InsideForest can automatically pick faster training parameters and reduce

--- a/docs/quick_api.html
+++ b/docs/quick_api.html
@@ -27,3 +27,8 @@ plt.scatter(y, y_pred)
 plt.show()
 regr.save("reg.joblib")
 regr2 = InsideForestRegressor.load("reg.joblib")</code></pre>
+
+<h2>Balanced clusters</h2>
+<p>Enable <code>balance_clusters=True</code> to automatically weight classes and switch to the
+<code>"menu"</code> cluster selector for multi-class data:</p>
+<pre><code class="language-python">clf = InsideForestClassifier(balance_clusters=True).fit(X, y)</code></pre>

--- a/docs/quick_api_es.html
+++ b/docs/quick_api_es.html
@@ -28,3 +28,8 @@ plt.scatter(y, y_pred)
 plt.show()
 regr.save("reg.joblib")
 regr2 = InsideForestRegressor.load("reg.joblib")</code></pre>
+
+<h2>Balanceo de clústeres</h2>
+<p>Activa <code>balance_clusters=True</code> para ponderar automáticamente las clases y usar el
+selector de clústeres <code>"menu"</code> al trabajar con datos multiclase:</p>
+<pre><code class="language-python">clf = InsideForestClassifier(balance_clusters=True).fit(X, y)</code></pre>

--- a/tests/test_inside_forest_fit_predict.py
+++ b/tests/test_inside_forest_fit_predict.py
@@ -210,3 +210,18 @@ def test_fit_respects_get_detail_flag():
     )
     model_detail.fit(X=X, y=y)
     assert model_detail.df_clusters_description_ is not None
+
+
+def test_balance_clusters_applies_balanced_settings():
+    import numpy as np
+
+    X = np.random.rand(60, 4)
+    y = np.concatenate([np.zeros(20), np.ones(20), np.full(20, 2)])
+
+    model = InsideForestClassifier(
+        rf_params={"n_estimators": 5, "random_state": 0}, balance_clusters=True
+    )
+    model.fit(X=X, y=y)
+
+    assert model.rf.get_params()["class_weight"] == "balanced"
+    assert model.method == "menu"

--- a/tests/test_inside_forest_params.py
+++ b/tests/test_inside_forest_params.py
@@ -15,6 +15,7 @@ def test_get_params_returns_init_values():
         method="balance_lists_n_clusters",
         divide=3,
         get_detail=True,
+        balance_clusters=True,
     )
     params = model.get_params()
     assert params["rf_params"]["n_estimators"] == 5
@@ -27,6 +28,7 @@ def test_get_params_returns_init_values():
     assert params["leaf_percentile"] == 96
     assert params["low_leaf_fraction"] == 0.03
     assert params["max_cases"] == 750
+    assert params["balance_clusters"] is True
     assert params["seed"] == 42
 
 
@@ -62,6 +64,9 @@ def test_set_params_updates_attributes():
     model.set_params(seed=123)
     assert model.seed == 123
     assert model.rf.get_params()["random_state"] == 123
+
+    model.set_params(balance_clusters=True)
+    assert model.balance_clusters is True
 
     with pytest.raises(ValueError):
         model.set_params(unknown=1)


### PR DESCRIPTION
## Summary
- add `balance_clusters` flag to enable balanced random forest and menu cluster selection for multi-class data
- document `balance_clusters` in both READMEs
- test new parameter wiring and behavior

## Testing
- `pytest tests/test_inside_forest_params.py tests/test_inside_forest_fit_predict.py::test_balance_clusters_applies_balanced_settings -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba039066b0832c9f9dcf0809020a02