### PR TITLE
Fix documentation layout and navigation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,3 @@
 title: InsideForest Documentation
 description: "InsideForest: supervised clustering with interpretable regions."
-remote_theme: just-the-docs/just-the-docs
-search_enabled: true
-sitemap: true
 keywords: InsideForest, clustering, interpretable, regions, trees

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: 'en' }}">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ page.title }} | {{ site.title }}</title>
+    {% if page.description or site.description %}
+    <meta name="description" content="{{ page.description | default: site.description }}">
+    {% endif %}
+    {% if page.keywords or site.keywords %}
+    <meta name="keywords" content="{{ page.keywords | default: site.keywords }}">
+    {% endif %}
+    <link rel="stylesheet" href="{{ '/style.css' | relative_url }}">
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container">
+        <a class="site-title" href="{{ '/' | relative_url }}">{{ site.title | default: 'Documentation' }}</a>
+      </div>
+    </header>
+    <div class="page-wrapper">
+      <nav class="sidebar">
+        {% assign visible_pages = site.html_pages | where_exp: 'p', 'p.nav_exclude != true' %}
+        {% assign sorted_pages = visible_pages | sort: 'nav_order' %}
+        <ul class="nav-list">
+          {% for nav_page in sorted_pages %}
+            {% unless nav_page.parent %}
+              <li class="{% if page.url == nav_page.url %}active{% endif %}">
+                <a href="{{ nav_page.url | relative_url }}">{{ nav_page.title }}</a>
+                {% assign children = visible_pages | where: 'parent', nav_page.title | sort: 'nav_order' %}
+                {% if children and nav_page.has_children %}
+                  <ul>
+                    {% for child in children %}
+                      <li class="{% if page.url == child.url %}active{% endif %}">
+                        <a href="{{ child.url | relative_url }}">{{ child.title }}</a>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                {% endif %}
+              </li>
+            {% endunless %}
+          {% endfor %}
+        </ul>
+      </nav>
+      <main class="content">
+        {{ content }}
+      </main>
+    </div>
+    <footer class="site-footer">
+      <div class="container">
+        <p>© {{ site.time | date: '%Y' }} {{ site.title | default: 'Documentation' }}</p>
+      </div>
+    </footer>
+    <script src="{{ '/lang.js' | relative_url }}" defer></script>
+  </body>
+</html>

--- a/docs/api/clusterselector.html
+++ b/docs/api/clusterselector.html
@@ -5,8 +5,6 @@ parent: InsideForest
 nav_order: 6
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="clusterselector_es.html">ES</a></div>
 <h1>MenuClusterSelector</h1>
 <h2>Signature</h2>

--- a/docs/api/clusterselector_es.html
+++ b/docs/api/clusterselector_es.html
@@ -6,8 +6,6 @@ nav_order: 6
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="clusterselector.html">EN</a></div>
 <h1>MenuClusterSelector</h1>
 <h2>Firma</h2>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -4,8 +4,6 @@ title: API Reference
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="index_es.html">ES</a></div>
 <h1>API Reference</h1>
 <p>Documentation for the InsideForest API.</p>

--- a/docs/api/index_es.html
+++ b/docs/api/index_es.html
@@ -4,8 +4,6 @@ title: Referencia API
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="index.html">EN</a></div>
 <h1>Referencia API</h1>
 <p>Documentación de la API de InsideForest.</p>

--- a/docs/api/insideforestclassifier.html
+++ b/docs/api/insideforestclassifier.html
@@ -5,8 +5,6 @@ parent: InsideForest
 nav_order: 1
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="insideforestclassifier_es.html">ES</a></div>
 <h1>InsideForestClassifier</h1>
 <h2>Signature</h2>

--- a/docs/api/insideforestclassifier_es.html
+++ b/docs/api/insideforestclassifier_es.html
@@ -6,8 +6,6 @@ nav_order: 1
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="insideforestclassifier.html">EN</a></div>
 <h1>InsideForestClassifier</h1>
 <h2>Firma</h2>

--- a/docs/api/insideforestregressor.html
+++ b/docs/api/insideforestregressor.html
@@ -5,8 +5,6 @@ parent: InsideForest
 nav_order: 2
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="insideforestregressor_es.html">ES</a></div>
 <h1>InsideForestRegressor</h1>
 <h2>Signature</h2>

--- a/docs/api/insideforestregressor_es.html
+++ b/docs/api/insideforestregressor_es.html
@@ -6,8 +6,6 @@ nav_order: 2
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="insideforestregressor.html">EN</a></div>
 <h1>InsideForestRegressor</h1>
 <h2>Firma</h2>

--- a/docs/api/labels.html
+++ b/docs/api/labels.html
@@ -5,8 +5,6 @@ parent: InsideForest
 nav_order: 4
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="labels_es.html">ES</a></div>
 <h1>Labels</h1>
 <h2>Signature</h2>

--- a/docs/api/labels_es.html
+++ b/docs/api/labels_es.html
@@ -6,8 +6,6 @@ nav_order: 4
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="labels.html">EN</a></div>
 <h1>Labels</h1>
 <h2>Firma</h2>

--- a/docs/api/metadata.html
+++ b/docs/api/metadata.html
@@ -5,8 +5,6 @@ parent: InsideForest
 nav_order: 7
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="metadata_es.html">ES</a></div>
 <h1>MetaExtractor</h1>
 <h2>Signature</h2>

--- a/docs/api/metadata_es.html
+++ b/docs/api/metadata_es.html
@@ -6,8 +6,6 @@ nav_order: 7
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="metadata.html">EN</a></div>
 <h1>MetaExtractor</h1>
 <h2>Firma</h2>

--- a/docs/api/models.html
+++ b/docs/api/models.html
@@ -5,8 +5,6 @@ parent: InsideForest
 nav_order: 6
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="models_es.html">ES</a></div>
 <h1>Models</h1>
 <h2>Signature</h2>

--- a/docs/api/models_es.html
+++ b/docs/api/models_es.html
@@ -6,8 +6,6 @@ nav_order: 6
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="models.html">EN</a></div>
 <h1>Models</h1>
 <h2>Firma</h2>

--- a/docs/api/regions.html
+++ b/docs/api/regions.html
@@ -5,8 +5,6 @@ parent: InsideForest
 nav_order: 3
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="regions_es.html">ES</a></div>
 <h1>Regions</h1>
 <h2>Signature</h2>

--- a/docs/api/regions_es.html
+++ b/docs/api/regions_es.html
@@ -6,8 +6,6 @@ nav_order: 3
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="regions.html">EN</a></div>
 <h1>Regions</h1>
 <h2>Firma</h2>

--- a/docs/api/trees.html
+++ b/docs/api/trees.html
@@ -5,8 +5,6 @@ parent: InsideForest
 nav_order: 5
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="trees_es.html">ES</a></div>
 <h1>Trees</h1>
 <h2>Signature</h2>

--- a/docs/api/trees_es.html
+++ b/docs/api/trees_es.html
@@ -6,8 +6,6 @@ nav_order: 5
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="trees.html">EN</a></div>
 <h1>Trees</h1>
 <h2>Firma</h2>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -5,8 +5,6 @@ description: Chronological list of InsideForest changes.
 nav_order: 92
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="changelog_es.html">ES</a></div>
 <h1>Changelog</h1>
 <p>Changes between versions.</p>

--- a/docs/changelog_es.html
+++ b/docs/changelog_es.html
@@ -6,8 +6,6 @@ nav_order: 92
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="changelog.html">EN</a></div>
 <h1>Registro de Cambios</h1>
 <p>Cambios entre versiones.</p>

--- a/docs/experiments_benchmarks.html
+++ b/docs/experiments_benchmarks.html
@@ -5,8 +5,6 @@ description: Experiments and benchmarks demonstrating InsideForest.
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="experiments_benchmarks_es.html">ES</a></div>
 <h1>Experiments and Benchmarks</h1>
 <p>Summary of datasets and metrics.</p>

--- a/docs/experiments_benchmarks_es.html
+++ b/docs/experiments_benchmarks_es.html
@@ -5,8 +5,6 @@ description: Experimentos y benchmarks que demuestran InsideForest.
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="experiments_benchmarks.html">EN</a></div>
 <h1>Experimentos y Benchmarks</h1>
 <p>Resumen de datasets y métricas.</p>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -5,8 +5,6 @@ description: Frequently asked questions about InsideForest usage.
 nav_order: 90
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="faq_es.html">ES</a></div>
 <h1>FAQ</h1>
 <p>Frequently asked questions.</p>

--- a/docs/faq_es.html
+++ b/docs/faq_es.html
@@ -6,8 +6,6 @@ nav_order: 90
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="faq.html">EN</a></div>
 <h1>Preguntas Frecuentes</h1>
 <p>Preguntas frecuentes.</p>

--- a/docs/guides/architecture.html
+++ b/docs/guides/architecture.html
@@ -5,8 +5,6 @@ parent: Guides
 nav_order: 3
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="architecture_es.html">ES</a></div>
 <h1>Architecture</h1>
 <p>Guide for architecture.</p>

--- a/docs/guides/architecture_es.html
+++ b/docs/guides/architecture_es.html
@@ -6,8 +6,6 @@ nav_order: 3
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="architecture.html">EN</a></div>
 <h1>Arquitectura</h1>
 <p>Guía de arquitectura.</p>

--- a/docs/guides/configuration.html
+++ b/docs/guides/configuration.html
@@ -5,8 +5,6 @@ parent: Guides
 nav_order: 1
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="configuration_es.html">ES</a></div>
 <h1>Configuration</h1>
 <p>Guide for configuration.</p>

--- a/docs/guides/configuration_es.html
+++ b/docs/guides/configuration_es.html
@@ -6,8 +6,6 @@ nav_order: 1
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="configuration.html">EN</a></div>
 <h1>Configuración</h1>
 <p>Guía de configuración.</p>

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -5,8 +5,6 @@ nav_order: 10
 has_children: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="index_es.html">ES</a></div>
 <h1>Guides</h1>
 <p>Conceptual guides for InsideForest.</p>

--- a/docs/guides/index_es.html
+++ b/docs/guides/index_es.html
@@ -6,8 +6,6 @@ has_children: true
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="index.html">EN</a></div>
 <h1>Guías</h1>
 <p>Guías conceptuales para InsideForest.</p>

--- a/docs/guides/interpretation.html
+++ b/docs/guides/interpretation.html
@@ -5,8 +5,6 @@ parent: Guides
 nav_order: 2
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="interpretation_es.html">ES</a></div>
 <h1>Interpretation</h1>
 <p>Guide for interpretation.</p>

--- a/docs/guides/interpretation_es.html
+++ b/docs/guides/interpretation_es.html
@@ -6,8 +6,6 @@ nav_order: 2
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="interpretation.html">EN</a></div>
 <h1>Interpretación</h1>
 <p>Guía de interpretación.</p>

--- a/docs/how_it_works.html
+++ b/docs/how_it_works.html
@@ -6,8 +6,6 @@ parent: InsideForest
 nav_order: 0
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="how_it_works_es.html">ES</a></div>
 <h1>How It Works</h1>
 <pre>Forest → Rules → Regions → Labels</pre>

--- a/docs/how_it_works_es.html
+++ b/docs/how_it_works_es.html
@@ -7,8 +7,6 @@ nav_order: 0
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="how_it_works.html">EN</a></div>
 <h1>Cómo Funciona</h1>
 <pre>Bosque → Reglas → Regiones → Etiquetas</pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,8 +6,6 @@ nav_order: 1
 has_children: true
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="index_es.html">ES</a></div>
 <h1>InsideForest</h1>
 <p>Clustering supervisado con regiones interpretables.</p>

--- a/docs/index_es.html
+++ b/docs/index_es.html
@@ -7,8 +7,6 @@ has_children: true
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="index.html">EN</a></div>
 <h1>InsideForest</h1>
 <p>Clustering supervisado con regiones interpretables.</p>

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -5,8 +5,6 @@ description: Install the InsideForest library and its dependencies.
 nav_order: 3
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="installation_es.html">ES</a></div>
 <h1>Installation</h1>
 <p>Install InsideForest from PyPI or in development mode.</p>

--- a/docs/installation_es.html
+++ b/docs/installation_es.html
@@ -6,8 +6,6 @@ nav_order: 3
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="installation.html">EN</a></div>
 <h1>Instalación</h1>
 <p>Instala InsideForest desde PyPI o en modo desarrollo.</p>

--- a/docs/license.html
+++ b/docs/license.html
@@ -5,8 +5,6 @@ description: License information for InsideForest.
 nav_order: 100
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="license_es.html">ES</a></div>
 <h1>License</h1>
 <p>Project license information.</p>

--- a/docs/license_es.html
+++ b/docs/license_es.html
@@ -6,8 +6,6 @@ nav_order: 100
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="license.html">EN</a></div>
 <h1>Licencia</h1>
 <p>Información de la licencia del proyecto.</p>

--- a/docs/performance_tips.html
+++ b/docs/performance_tips.html
@@ -5,8 +5,6 @@ description: Tips to improve InsideForest performance.
 nav_order: 9
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="performance_tips_es.html">ES</a></div>
 <h1>Performance Tips</h1>
 <ul>

--- a/docs/performance_tips_es.html
+++ b/docs/performance_tips_es.html
@@ -6,8 +6,6 @@ nav_order: 9
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="performance_tips.html">EN</a></div>
 <h1>Consejos de Rendimiento</h1>
 <ul>

--- a/docs/quick_api.html
+++ b/docs/quick_api.html
@@ -5,8 +5,6 @@ description: Quick reference for using InsideForest's API.
 nav_order: 5
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="quick_api_es.html">ES</a></div>
 <h1>Quick API</h1>
 <h2>Classifier</h2>

--- a/docs/quick_api_es.html
+++ b/docs/quick_api_es.html
@@ -6,8 +6,6 @@ nav_order: 5
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="quick_api.html">EN</a></div>
 <h1>API Rápida</h1>
 <h2>Clasificador</h2>

--- a/docs/reproducibility.html
+++ b/docs/reproducibility.html
@@ -5,8 +5,6 @@ description: Reproducibility guidelines for InsideForest experiments.
 nav_order: 4
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="reproducibility_es.html">ES</a></div>
 <h1>Reproducibility</h1>
 <ul>

--- a/docs/reproducibility_es.html
+++ b/docs/reproducibility_es.html
@@ -6,8 +6,6 @@ nav_order: 4
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="reproducibility.html">EN</a></div>
 <h1>Reproducibilidad</h1>
 <ul>

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -5,8 +5,6 @@ description: Future development roadmap for InsideForest.
 nav_order: 91
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="roadmap_es.html">ES</a></div>
 <h1>Roadmap</h1>
 <p>Upcoming features.</p>

--- a/docs/roadmap_es.html
+++ b/docs/roadmap_es.html
@@ -6,8 +6,6 @@ nav_order: 91
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="style.css">
-<script src="lang.js"></script>
 <div class="lang-switch"><a href="roadmap.html">EN</a></div>
 <h1>Hoja de Ruta</h1>
 <p>Funciones futuras.</p>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,17 +1,198 @@
-.lang-switch {
-  text-align: right;
+:root {
+  --sidebar-width: 260px;
+  --border-color: #e1e4e8;
+  --link-color: #005cc5;
+  --background: #f6f8fa;
+  --text-color: #1a1a1a;
 }
 
-/* Copy button for code blocks */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", Tahoma, sans-serif;
+  background: var(--background);
+  color: var(--text-color);
+  line-height: 1.6;
+}
+
+a {
+  color: var(--link-color);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.site-header {
+  background: #fff;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.site-header .container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+}
+
+.site-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.page-wrapper {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  display: flex;
+  gap: 2rem;
+}
+
+.sidebar {
+  width: var(--sidebar-width);
+  border-right: 1px solid var(--border-color);
+  padding-right: 1.5rem;
+  position: sticky;
+  top: 80px;
+  align-self: flex-start;
+  max-height: calc(100vh - 120px);
+  overflow-y: auto;
+  background: #fff;
+}
+
+.nav-list,
+.nav-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-list > li {
+  margin-bottom: 0.75rem;
+}
+
+.nav-list a {
+  color: inherit;
+}
+
+.nav-list li.active > a {
+  font-weight: 600;
+  color: var(--link-color);
+}
+
+.nav-list ul {
+  margin-top: 0.5rem;
+  padding-left: 1rem;
+  border-left: 2px solid var(--border-color);
+}
+
+.nav-list ul li {
+  margin-bottom: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.content {
+  flex: 1 1 0;
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.1);
+}
+
+.content h1:first-of-type {
+  margin-top: 0;
+}
+
+.lang-switch {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+
+.lang-switch a {
+  font-weight: 500;
+}
+
+p {
+  margin: 0 0 1rem;
+}
+
+ul,
+ol {
+  padding-left: 1.25rem;
+}
+
 pre {
   position: relative;
+  background: #0f172a;
+  color: #f1f5f9;
+  padding: 1rem;
+  border-radius: 6px;
+  overflow-x: auto;
+  margin: 1rem 0;
+}
+
+code {
+  font-family: "Source Code Pro", "Menlo", monospace;
 }
 
 .copy-button {
   position: absolute;
-  top: 4px;
-  right: 4px;
-  padding: 2px 6px;
-  font-size: 0.8em;
+  top: 8px;
+  right: 8px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.8rem;
+  border: none;
+  background: rgba(148, 163, 184, 0.2);
+  color: inherit;
+  border-radius: 4px;
   cursor: pointer;
+}
+
+.copy-button:hover {
+  background: rgba(148, 163, 184, 0.35);
+}
+
+.site-footer {
+  margin-top: 2rem;
+  padding: 1.5rem 1rem 3rem;
+  border-top: 1px solid var(--border-color);
+  background: #fff;
+}
+
+.site-footer .container {
+  max-width: 1200px;
+  margin: 0 auto;
+  color: #4b5563;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 1024px) {
+  .page-wrapper {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    position: static;
+    max-height: none;
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 1rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .content {
+    padding: 1.5rem;
+  }
+
+  pre {
+    font-size: 0.9rem;
+  }
 }

--- a/docs/tutorials/classification.html
+++ b/docs/tutorials/classification.html
@@ -5,8 +5,6 @@ parent: Tutorials
 nav_order: 1
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="classification_es.html">ES</a></div>
 <h1>Classification</h1>
 <p>Tutorial for classification.</p>

--- a/docs/tutorials/classification_es.html
+++ b/docs/tutorials/classification_es.html
@@ -6,8 +6,6 @@ nav_order: 1
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="classification.html">EN</a></div>
 <h1>Clasificación</h1>
 <p>Tutorial de clasificación.</p>

--- a/docs/tutorials/index.html
+++ b/docs/tutorials/index.html
@@ -5,8 +5,6 @@ nav_order: 11
 has_children: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="index_es.html">ES</a></div>
 <h1>Tutorials</h1>
 <p>Step-by-step tutorials for InsideForest.</p>

--- a/docs/tutorials/index_es.html
+++ b/docs/tutorials/index_es.html
@@ -6,8 +6,6 @@ has_children: true
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="index.html">EN</a></div>
 <h1>Tutoriales</h1>
 <p>Tutoriales paso a paso para InsideForest.</p>

--- a/docs/tutorials/persistence.html
+++ b/docs/tutorials/persistence.html
@@ -5,8 +5,6 @@ parent: Tutorials
 nav_order: 4
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="persistence_es.html">ES</a></div>
 <h1>Persistence</h1>
 <p>Tutorial for persistence.</p>

--- a/docs/tutorials/persistence_es.html
+++ b/docs/tutorials/persistence_es.html
@@ -6,8 +6,6 @@ nav_order: 4
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="persistence.html">EN</a></div>
 <h1>Persistencia</h1>
 <p>Tutorial de persistencia.</p>

--- a/docs/tutorials/pipeline.html
+++ b/docs/tutorials/pipeline.html
@@ -5,8 +5,6 @@ parent: Tutorials
 nav_order: 3
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="pipeline_es.html">ES</a></div>
 <h1>Pipeline</h1>
 <p>Tutorial for pipeline.</p>

--- a/docs/tutorials/pipeline_es.html
+++ b/docs/tutorials/pipeline_es.html
@@ -6,8 +6,6 @@ nav_order: 3
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="pipeline.html">EN</a></div>
 <h1>Pipeline</h1>
 <p>Tutorial de pipeline.</p>

--- a/docs/tutorials/regression.html
+++ b/docs/tutorials/regression.html
@@ -5,8 +5,6 @@ parent: Tutorials
 nav_order: 2
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="regression_es.html">ES</a></div>
 <h1>Regression</h1>
 <p>Tutorial for regression.</p>

--- a/docs/tutorials/regression_es.html
+++ b/docs/tutorials/regression_es.html
@@ -6,8 +6,6 @@ nav_order: 2
 nav_exclude: true
 ---
 
-<link rel="stylesheet" href="../style.css">
-<script src="../lang.js"></script>
 <div class="lang-switch"><a href="regression.html">EN</a></div>
 <h1>Regresión</h1>
 <p>Tutorial de regresión.</p>


### PR DESCRIPTION
## Summary
- add a custom `default` layout that renders a persistent sidebar navigation and loads shared assets for every documentation page
- refresh the documentation stylesheet to provide a polished layout, responsive behaviour, and better code block presentation
- simplify individual HTML pages and the docs configuration now that the layout handles metadata and assets

## Testing
- pytest *(interrupted after ~5m because the suite continued running in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3cd26369c832cb28a717c8b1f732e