### PR TITLE
Relocate docs search bar to header

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -14,18 +14,32 @@
   </head>
   <body>
     <header class="site-header">
-      <div class="container">
+      <div class="container header-bar">
         <a class="site-title" href="{{ '/' | relative_url }}">{{ site.title | default: 'Documentation' }}</a>
+        <div class="search-panel">
+          <label class="visually-hidden" for="doc-search-input">Search the documentation</label>
+          <input
+            id="doc-search-input"
+            class="search-input"
+            type="search"
+            placeholder="Search / Buscar"
+            autocomplete="off"
+            spellcheck="false"
+            aria-describedby="doc-search-hint"
+          />
+          <p id="doc-search-hint" class="search-hint">Type to filter topics in English or Spanish.</p>
+          <div
+            id="doc-search-results"
+            class="search-results"
+            role="listbox"
+            aria-label="Search results"
+            aria-live="polite"
+          ></div>
+        </div>
       </div>
     </header>
     <div class="page-wrapper">
       <nav class="sidebar">
-        <div class="search-panel">
-          <label class="visually-hidden" for="doc-search-input">Search the documentation</label>
-          <input id="doc-search-input" class="search-input" type="search" placeholder="Search / Buscar" autocomplete="off" spellcheck="false" aria-describedby="doc-search-hint" />
-          <p id="doc-search-hint" class="search-hint">Type to filter topics in English or Spanish.</p>
-          <div id="doc-search-results" class="search-results" role="listbox" aria-label="Search results" aria-live="polite"></div>
-        </div>
         {% assign visible_pages = site.html_pages | where_exp: 'p', 'p.nav_exclude != true' %}
         {% assign sorted_pages = visible_pages | sort: 'nav_order' %}
         <ul class="nav-list">

--- a/docs/style.css
+++ b/docs/style.css
@@ -35,18 +35,31 @@ a:hover {
   border-bottom: 1px solid var(--border-color);
 }
 
-.site-header .container {
+.site-header .header-bar {
   max-width: 1200px;
   margin: 0 auto;
   padding: 1rem;
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
 }
 
 .site-title {
   font-size: 1.25rem;
   font-weight: 600;
   color: var(--link-color);
+}
+
+.search-panel {
+  position: relative;
+  flex: 1 1 320px;
+  max-width: 460px;
+  margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
 .page-wrapper {
@@ -84,17 +97,6 @@ a:hover {
   border: 0;
 }
 
-.search-panel {
-  position: sticky;
-  top: 0;
-  background: #fff;
-  padding: 0 1.5rem 1rem 1.5rem;
-  margin: -1rem -1.5rem 1rem -1.5rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.4);
-  box-shadow: 0 4px 8px -6px rgba(15, 23, 42, 0.2);
-  z-index: 2;
-}
-
 .search-input {
   width: 100%;
   padding: 0.65rem 0.85rem;
@@ -113,11 +115,14 @@ a:hover {
 .search-hint {
   font-size: 0.75rem;
   color: #64748b;
-  margin: 0.35rem 0 0;
+  margin: 0;
 }
 
 .search-results {
-  margin-top: 0.75rem;
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  right: 0;
   border: 1px solid rgba(148, 163, 184, 0.4);
   border-radius: 8px;
   max-height: 320px;
@@ -125,6 +130,7 @@ a:hover {
   background: #fff;
   box-shadow: 0 6px 20px -12px rgba(15, 23, 42, 0.4);
   display: none;
+  z-index: 10;
 }
 
 .search-results.active {


### PR DESCRIPTION
## Summary
- move the documentation search input into the header beside the title
- adjust documentation styles so the header layout supports the repositioned search dropdown

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e46699d86c832cb9bae075b8594ec2