### PR TITLE
Default no_trees_search to 300 when unspecified

### DIFF
--- a/tests/test_inside_forest_params.py
+++ b/tests/test_inside_forest_params.py
@@ -10,6 +10,7 @@ def test_get_params_returns_init_values():
     model = InsideForestClassifier(
         rf_params={"n_estimators": 5},
         tree_params={"lang": "python"},
+        no_trees_search=10,
         n_clusters=2,
         include_summary_cluster=True,
         method="balance_lists_n_clusters",
@@ -20,6 +21,7 @@ def test_get_params_returns_init_values():
     params = model.get_params()
     assert params["rf_params"]["n_estimators"] == 5
     assert params["tree_params"]["lang"] == "python"
+    assert params["no_trees_search"] == 10
     assert params["n_clusters"] == 2
     assert params["include_summary_cluster"] is True
     assert params["method"] == "balance_lists_n_clusters"
@@ -30,6 +32,21 @@ def test_get_params_returns_init_values():
     assert params["max_cases"] == 750
     assert params["balance_clusters"] is True
     assert params["seed"] == 42
+    assert model.trees.no_trees_search == 10
+
+
+def test_no_trees_search_defaults_to_300():
+    model = InsideForestClassifier()
+    assert model.no_trees_search == 300
+    assert model.tree_params["no_trees_search"] == 300
+    assert model.trees.no_trees_search == 300
+
+
+def test_no_trees_search_can_be_disabled():
+    model = InsideForestClassifier(no_trees_search=None)
+    assert model.no_trees_search is None
+    assert "no_trees_search" not in model.tree_params
+    assert model.trees.no_trees_search is None
 
 
 def test_set_params_updates_attributes():
@@ -60,6 +77,16 @@ def test_set_params_updates_attributes():
     assert model.low_leaf_fraction == 0.1
     model.set_params(max_cases=100)
     assert model.max_cases == 100
+
+    model.set_params(no_trees_search=15)
+    assert model.no_trees_search == 15
+    assert model.tree_params["no_trees_search"] == 15
+    assert model.trees.no_trees_search == 15
+
+    model.set_params(tree_params__no_trees_search=20)
+    assert model.no_trees_search == 20
+    assert model.tree_params["no_trees_search"] == 20
+    assert model.trees.no_trees_search == 20
 
     model.set_params(seed=123)
     assert model.seed == 123


### PR DESCRIPTION
## Summary
- default the InsideForest wrappers' `no_trees_search` parameter to 300 when unspecified and ensure it flows through tree params, auto-fast overrides, and persistence
- allow explicitly disabling the limit with `None` while updating the Trees documentation to reflect the new default
- extend the parameter tests to cover the new default and the ability to opt out

## Testing
- pytest tests/test_inside_forest_params.py

------
https://chatgpt.com/codex/tasks/task_e_68e48c069bdc832c9499eeb0cd1b6acf