### PR TITLE
docs: add guidance to optimize unsupervised menu clustering

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -95,6 +95,42 @@ Puedes controlar cómo se eligen las etiquetas finales mediante el parámetro
 - `"max_prob_clusters"`: prioriza los clústers con mayor probabilidad
 - `"menu"`: aplica `MenuClusterSelector` para maximizar un objetivo informativo global
 
+### Optimizar la fase no supervisada (`method="menu"`)
+
+Si tu cuello de botella está en la selección no supervisada de clústers,
+estas prácticas suelen dar mejoras rápidas de tiempo/memoria:
+
+1. **Reducir el catálogo antes de optimizar**
+   - Usa `n_clusters` en `predict` para limitar el espacio de búsqueda a un
+     conjunto de valores candidato más pequeño.
+   - Esto reduce el costo de cada iteración del esquema greedy.
+
+2. **Comprimir rarezas de reglas**
+   - Agrupa valores/reglas muy poco frecuentes en una categoría de respaldo
+     antes de ejecutar `MenuClusterSelector`.
+   - Menos cardinalidad implica menos combinaciones en la optimización.
+
+3. **Afinar el balance calidad vs. complejidad**
+   - Incrementa la penalización de complejidad (`lambda_reg`) cuando observes
+     sobrefragmentación en demasiados clústers pequeños.
+   - Ajusta los pesos de objetivo (`w_nmi`, `w_v`) según tu KPI final
+     (pureza, estabilidad o interpretabilidad).
+
+4. **Pre-filtrado de variables**
+   - Activa `auto_feature_reduce=True` o fija `explicit_k_features` para
+     alimentar menos ruido a la etapa de reglas.
+   - En datasets anchos, esto suele acelerar tanto entrenamiento como selección.
+
+5. **Controlar la granularidad de reglas**
+   - Disminuye ramas excesivas (por ejemplo bajando complejidad del bosque) si
+     detectas miles de reglas casi redundantes.
+   - Menos reglas útiles elevan la relación señal/ruido para el selector.
+
+6. **Optimización por bloques para grandes volúmenes**
+   - Si el dataset es muy grande, prueba un flujo por lotes: optimiza sobre una
+     muestra representativa y luego aplica reglas al resto.
+   - Recalibra periódicamente con una nueva muestra para evitar deriva.
+
 Después del ajuste, puedes consultar las importancias de las variables del
 bosque aleatorio y visualizarlas opcionalmente:
 
@@ -367,4 +403,3 @@ Esto produce un `DataFrame` resumen donde cada condición se etiqueta por grupo 
 ## Utilidades de optimización
 
 InsideForest ahora incluye un optimizador de Newton con región de confianza para problemas con restricciones de caja. La función auxiliar `_find_maximum` expone el parámetro `optim_method` para alternar entre el ascenso por gradiente estándar y este enfoque de región de confianza, que usa derivadas analíticas o por diferencias finitas y suele converger con menos evaluaciones respetando los límites.
-


### PR DESCRIPTION
### Motivation
- Improve user guidance for optimizing the unsupervised selection stage when using `method="menu"` because this stage can be a time/memory bottleneck on large or high-cardinality problems.

### Description
- Added a new section to `README.es.md` titled "Optimizar la fase no supervisada (`method="menu"`)" with concrete recommendations and best practices.
- Recommendations cover limiting the search space via `n_clusters`, compressing rare rules, tuning complexity regularization (`lambda_reg`) and objective weights (`w_nmi`, `w_v`), using `auto_feature_reduce` or `explicit_k_features`, controlling tree/rule granularity, and batch/sample-based optimization workflows.
- This change is documentation-only and does not modify runtime code or algorithms.

### Testing
- Ran the focused cluster-selection test suite with `pytest -q tests/test_cluster_selector.py` which completed successfully with `6 passed` and expected warnings about unassigned records.
- No code changes required re-running full test matrix since the modification is non-functional and limited to documentation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e94ab90564832c8f29c7d00d6a64d2)