### PR TITLE
[codex] Make OpenAI hypotheses model-agnostic

### DIFF
--- a/InsideForest/__init__.py
+++ b/InsideForest/__init__.py
@@ -41,6 +41,7 @@ from .region_quality import (
     summarize_region_quality,
     cluster_label_quality,
 )
+from .descrip import generate_model_hypothesis
 
 __version__ = "0.4.3"
 

--- a/InsideForest/descrip.py
+++ b/InsideForest/descrip.py
@@ -1069,6 +1069,418 @@ def _local_hypothesis_text(
     )
 
 
+def _call_openai_text(
+    payload: dict[str, Any],
+    *,
+    system_prompt: str,
+    model: str,
+    temperature: float,
+    api_key: Optional[str] = None,
+    client: Any | None = None,
+) -> Optional[str]:
+    """Return one OpenAI response, or ``None`` so callers can fall back."""
+    if client is None:
+        client = get_openai_client(api_key)
+    if client is None:
+        logger.warning("OpenAI client unavailable; using the local report")
+        return None
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            temperature=temperature,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
+            ],
+        )
+        choices = getattr(response, "choices", None)
+        content = (
+            getattr(getattr(choices[0], "message", None), "content", None)
+            if choices
+            else None
+        )
+        if not content:
+            logger.warning("OpenAI returned no text; using the local report")
+            return None
+        return str(content).strip()
+    except Exception as exc:
+        logger.warning("OpenAI request failed; using the local report: %s", exc)
+        return None
+
+
+def _model_hypothesis_task(regions: pd.DataFrame) -> str:
+    """Infer an InsideForest task from its public region schema."""
+    columns = set(regions.columns)
+    if "target_mean" in columns and (
+        "mean_shift" in columns or "dispersion_reduction" in columns
+    ):
+        return "regression"
+    if "class_distribution" in columns and (
+        "region_target_class" in columns
+        or "target_class" in columns
+        or "dominant_class" in columns
+    ):
+        return "multiclass"
+    if "target_distribution" in columns and "dominant_target" in columns:
+        return "classification"
+    raise ValueError(
+        "Could not infer the task from explain_regions(); expected an "
+        "InsideForest traditional, multiclass, or regression schema"
+    )
+
+
+def _finite_float(value: Any) -> Optional[float]:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if np.isfinite(number) else None
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return [_json_value(item) for item in value.tolist()]
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, np.generic):
+        value = value.item()
+    try:
+        return None if pd.isna(value) else value
+    except (TypeError, ValueError):
+        return value
+
+
+def _class_distribution(value: Any, classes: Any = None) -> dict[str, float]:
+    if isinstance(value, str):
+        try:
+            value = ast.literal_eval(value)
+        except (SyntaxError, ValueError):
+            return {}
+    if isinstance(value, dict):
+        items = value.items()
+    elif isinstance(value, (list, tuple, np.ndarray)):
+        values = list(value)
+        labels = list(classes) if classes is not None else list(range(len(values)))
+        items = zip(labels, values)
+    else:
+        return {}
+    result = {}
+    for label, raw_value in items:
+        number = _finite_float(raw_value)
+        if number is not None:
+            result[str(label)] = number
+    return result
+
+
+def _region_id_column(regions: pd.DataFrame) -> str:
+    for column in ("region_id", "cluster_id"):
+        if column in regions.columns:
+            return column
+    raise ValueError("explain_regions() must expose region_id or cluster_id")
+
+
+def _dominant_class(row: pd.Series, task: str) -> Any:
+    columns = (
+        ("dominant_target", "region_target_class")
+        if task == "classification"
+        else ("dominant_class", "target_class", "region_target_class")
+    )
+    for column in columns:
+        value = _json_value(row.get(column))
+        if value is not None:
+            return value
+    return None
+
+
+def _row_score(row: pd.Series) -> float:
+    for column in ("region_score", "score", "weight", "support"):
+        value = _finite_float(row.get(column))
+        if value is not None:
+            return value
+    return 0.0
+
+
+def _select_model_regions(
+    regions: pd.DataFrame, task: str, region_ids: Optional[Any]
+) -> tuple[pd.Series, pd.Series, str]:
+    id_column = _region_id_column(regions)
+    if region_ids is not None:
+        requested = list(region_ids)
+        if len(requested) != 2 or requested[0] == requested[1]:
+            raise ValueError("region_ids must contain exactly two distinct IDs")
+        selected = []
+        for region_id in requested:
+            match = regions[regions[id_column] == region_id]
+            if match.empty:
+                raise ValueError(f"Unknown region ID: {region_id!r}")
+            selected.append(match.iloc[0])
+        return selected[0], selected[1], id_column
+
+    if task == "regression":
+        means = pd.to_numeric(regions["target_mean"], errors="coerce")
+        valid = regions.loc[means.notna()].copy()
+        valid["__mean"] = means[means.notna()]
+        if len(valid) < 2:
+            raise ValueError("At least two regions with numeric target_mean are required")
+        ordered = valid.sort_values("__mean", kind="stable")
+        return ordered.iloc[0], ordered.iloc[-1], id_column
+
+    order = sorted(
+        range(len(regions)),
+        key=lambda index: _row_score(regions.iloc[index]),
+        reverse=True,
+    )
+    first = regions.iloc[order[0]]
+    first_class = _dominant_class(first, task)
+    for index in order[1:]:
+        candidate = regions.iloc[index]
+        if _dominant_class(candidate, task) != first_class:
+            return first, candidate, id_column
+    return first, regions.iloc[order[1]], id_column
+
+
+def _normalized_model_region(
+    row: pd.Series, *, task: str, id_column: str, classes: Any = None
+) -> dict[str, Any]:
+    region = {
+        "region_id": _json_value(row.get(id_column)),
+        "description": str(row.get("description", "—")),
+        "support": _json_value(row.get("support")),
+        "coverage": _json_value(row.get("coverage")),
+        "region_score": _json_value(
+            row.get("region_score", row.get("score", row.get("weight")))
+        ),
+    }
+    if task == "classification":
+        region.update(
+            dominant_class=_dominant_class(row, task),
+            dominant_probability=_json_value(row.get("dominant_probability")),
+            class_distribution=_class_distribution(
+                row.get("target_distribution"), classes
+            ),
+            lift=_json_value(row.get("lift")),
+        )
+    elif task == "multiclass":
+        region.update(
+            dominant_class=_dominant_class(row, task),
+            target_probability=_json_value(
+                row.get("target_probability", row.get("dominant_probability"))
+            ),
+            class_distribution=_class_distribution(
+                row.get("class_distribution"), classes
+            ),
+            class_margin=_json_value(row.get("class_margin")),
+            lift=_json_value(row.get("lift")),
+            entropy=_json_value(row.get("entropy")),
+        )
+    else:
+        for column in (
+            "target_mean",
+            "target_median",
+            "target_std",
+            "target_iqr",
+            "mean_shift",
+            "standardized_mean_shift",
+            "dispersion_reduction",
+        ):
+            region[column] = _json_value(row.get(column))
+    return region
+
+
+def _number_text(value: Any) -> str:
+    number = _finite_float(value)
+    return "—" if number is None else f"{number:,.3f}"
+
+
+def _probability_text(value: Any) -> str:
+    number = _finite_float(value)
+    return "—" if number is None else f"{number:.2%}"
+
+
+def _distribution_text(distribution: dict[str, float]) -> str:
+    if not distribution:
+        return "—"
+    return ", ".join(
+        f"{label}: {_probability_text(value)}"
+        for label, value in distribution.items()
+    )
+
+
+def _local_model_hypothesis(payload: dict[str, Any]) -> str:
+    task, lang = payload["task"], payload["lang"]
+    target = payload["target"]
+    a, b = payload["regions"]
+    if lang == "es" and task == "regression":
+        difference = (_finite_float(b["target_mean"]) or 0.0) - (
+            _finite_float(a["target_mean"]) or 0.0
+        )
+        return (
+            f"# Comparación de regiones — regresión ({target})\n\n"
+            f"## Región {a['region_id']}\n- Reglas: **{a['description']}**\n"
+            f"- Media del objetivo: **{_number_text(a['target_mean'])}**\n"
+            f"- Mediana: **{_number_text(a['target_median'])}**\n"
+            f"- Desviación estándar: **{_number_text(a['target_std'])}**\n"
+            f"- Desplazamiento de la media: **{_number_text(a['mean_shift'])}**\n\n"
+            f"## Región {b['region_id']}\n- Reglas: **{b['description']}**\n"
+            f"- Media del objetivo: **{_number_text(b['target_mean'])}**\n"
+            f"- Mediana: **{_number_text(b['target_median'])}**\n"
+            f"- Desviación estándar: **{_number_text(b['target_std'])}**\n"
+            f"- Reducción de dispersión: **{_number_text(b['dispersion_reduction'])}**\n\n"
+            f"## Hipótesis\nLa región {b['region_id']} presenta una media "
+            f"**{difference:+,.3f}** mayor que la región {a['region_id']}. "
+            "Conviene validar las reglas diferenciales fuera de muestra."
+        )
+    if lang == "es" and task == "multiclass":
+        return (
+            f"# Comparación de regiones — multiclase ({target})\n\n"
+            f"## Región {a['region_id']}\n- Reglas: **{a['description']}**\n"
+            f"- Clase dominante: **{a['dominant_class']}**\n"
+            f"- Distribución: **{_distribution_text(a['class_distribution'])}**\n"
+            f"- Margen / lift / entropía: **{_number_text(a['class_margin'])} / "
+            f"{_number_text(a['lift'])} / {_number_text(a['entropy'])}**\n\n"
+            f"## Región {b['region_id']}\n- Reglas: **{b['description']}**\n"
+            f"- Clase dominante: **{b['dominant_class']}**\n"
+            f"- Distribución: **{_distribution_text(b['class_distribution'])}**\n"
+            f"- Margen / lift / entropía: **{_number_text(b['class_margin'])} / "
+            f"{_number_text(b['lift'])} / {_number_text(b['entropy'])}**\n\n"
+            "## Hipótesis\nLas reglas separan clases dominantes distintas. Un margen "
+            "bajo o una entropía alta señalan mayor ambigüedad."
+        )
+    if lang == "es":
+        return (
+            f"# Comparación de regiones — clasificación ({target})\n\n"
+            f"## Región {a['region_id']}\n- Reglas: **{a['description']}**\n"
+            f"- Clase dominante: **{a['dominant_class']}**\n"
+            f"- Probabilidad dominante: **{_probability_text(a['dominant_probability'])}**\n"
+            f"- Distribución: **{_distribution_text(a['class_distribution'])}**\n\n"
+            f"## Región {b['region_id']}\n- Reglas: **{b['description']}**\n"
+            f"- Clase dominante: **{b['dominant_class']}**\n"
+            f"- Probabilidad dominante: **{_probability_text(b['dominant_probability'])}**\n"
+            f"- Distribución: **{_distribution_text(b['class_distribution'])}**\n\n"
+            "## Hipótesis\nLas condiciones diferenciales concentran clases distintas; "
+            "la probabilidad dominante estima la pureza de cada región."
+        )
+    if task == "regression":
+        difference = (_finite_float(b["target_mean"]) or 0.0) - (
+            _finite_float(a["target_mean"]) or 0.0
+        )
+        return (
+            f"# Region comparison — regression ({target})\n\n"
+            f"## Region {a['region_id']}\n- Rules: **{a['description']}**\n"
+            f"- Target mean: **{_number_text(a['target_mean'])}**\n"
+            f"- Median: **{_number_text(a['target_median'])}**\n"
+            f"- Standard deviation: **{_number_text(a['target_std'])}**\n\n"
+            f"## Region {b['region_id']}\n- Rules: **{b['description']}**\n"
+            f"- Target mean: **{_number_text(b['target_mean'])}**\n"
+            f"- Median: **{_number_text(b['target_median'])}**\n"
+            f"- Standard deviation: **{_number_text(b['target_std'])}**\n\n"
+            f"## Hypothesis\nRegion {b['region_id']} has a **{difference:+,.3f}** "
+            f"higher mean than region {a['region_id']}; validate it out of sample."
+        )
+    noun = "multiclass" if task == "multiclass" else "classification"
+    probability_a = (
+        _distribution_text(a["class_distribution"])
+        if task == "multiclass"
+        else _probability_text(a["dominant_probability"])
+    )
+    probability_b = (
+        _distribution_text(b["class_distribution"])
+        if task == "multiclass"
+        else _probability_text(b["dominant_probability"])
+    )
+    return (
+        f"# Region comparison — {noun} ({target})\n\n"
+        f"## Region {a['region_id']}\n- Rules: **{a['description']}**\n"
+        f"- Dominant class: **{a['dominant_class']}**\n- Profile: **{probability_a}**\n\n"
+        f"## Region {b['region_id']}\n- Rules: **{b['description']}**\n"
+        f"- Dominant class: **{b['dominant_class']}**\n- Profile: **{probability_b}**\n\n"
+        "## Hypothesis\nThe differing rules concentrate different target profiles."
+    )
+
+
+def generate_model_hypothesis(
+    estimator: Any,
+    *,
+    target: Optional[str] = None,
+    meta_df: Optional[pd.DataFrame] = None,
+    lang: str = "es",
+    use_gpt: bool = False,
+    openai_model: str = "gpt-4o-mini",
+    temperature: float = 0.2,
+    region_ids: Optional[Any] = None,
+    top_n: int = 50,
+    api_key: Optional[str] = None,
+    client: Any | None = None,
+) -> str:
+    """Compare regions from any fitted canonical InsideForest estimator."""
+    if not hasattr(estimator, "explain_regions"):
+        raise TypeError("estimator must expose an explain_regions() method")
+    if lang not in {"es", "en"}:
+        raise ValueError("lang must be 'es' or 'en'")
+    try:
+        regions = estimator.explain_regions(
+            top_n=None if region_ids is not None else top_n
+        )
+    except Exception as exc:
+        raise ValueError(
+            "The estimator must be fitted before generating a hypothesis"
+        ) from exc
+    if not isinstance(regions, pd.DataFrame):
+        regions = pd.DataFrame(regions)
+    if len(regions) < 2:
+        raise ValueError("At least two explained regions are required")
+
+    task = _model_hypothesis_task(regions)
+    row_a, row_b, id_column = _select_model_regions(regions, task, region_ids)
+    target_label = target or ("objetivo" if lang == "es" else "target")
+    if target is not None and meta_df is not None:
+        try:
+            target_label = _meta_lookup(target, meta_df, lang=lang)[0]
+        except Exception:
+            target_label = target
+    payload = {
+        "lang": lang,
+        "task": task,
+        "target": target_label,
+        "regions": [
+            _normalized_model_region(
+                row_a,
+                task=task,
+                id_column=id_column,
+                classes=getattr(estimator, "classes_", None),
+            ),
+            _normalized_model_region(
+                row_b,
+                task=task,
+                id_column=id_column,
+                classes=getattr(estimator, "classes_", None),
+            ),
+        ],
+    }
+    local_report = _local_model_hypothesis(payload)
+    if not use_gpt:
+        return local_report
+    generated = _call_openai_text(
+        payload,
+        system_prompt=(
+            "You are a data-science expert. Return one concise Markdown report "
+            "in the requested language. Compare exactly the supplied regions "
+            "without inventing metrics. Adapt terminology to the task: class "
+            "probabilities for classification; distributions, margin, lift and "
+            "entropy for multiclass; numeric means, medians and dispersion for "
+            "regression. Never format continuous target values as percentages. "
+            "End with a testable, non-causal hypothesis."
+        ),
+        model=openai_model,
+        temperature=temperature,
+        api_key=api_key,
+        client=client,
+    )
+    return generated or local_report
+
+
 def _gpt_hypothesis(
     payload: dict[str, Any], *, model: str, temperature: float, client: Any | None = None
 ) -> Optional[str]:
@@ -1128,6 +1540,8 @@ def generate_hypothesis(
     use_gpt: bool = False,
     gpt_model: str = "gpt-4o-mini",
     temperature: float = 0.2,
+    api_key: Optional[str] = None,
+    client: Any | None = None,
 ) -> str:
     """Create a hypothesis report comparing two subgroups."""
     row = exp_df.iloc[0]
@@ -1146,8 +1560,8 @@ def generate_hypothesis(
 
     # ===== GPT PATH =====
     if use_gpt:
-        client = _client
-        if client is not None:
+        resolved_client = client or get_openai_client(api_key)
+        if resolved_client is not None:
             payload = {
                 "lang": lang,
                 "target": _meta_lookup(target, meta_df, lang=lang)[0],
@@ -1175,11 +1589,22 @@ def generate_hypothesis(
                 },
             }
 
-            txt = _gpt_hypothesis(
-                payload, model=gpt_model, temperature=temperature, client=client
+            txt = _call_openai_text(
+                payload,
+                system_prompt=(
+                    "You are a data-science expert assistant. Return one concise "
+                    "Markdown report in the language specified by 'lang'. Compare "
+                    "the two subgroups using only the supplied rules and metrics, "
+                    "then propose a testable A/B hypothesis."
+                ),
+                model=gpt_model,
+                temperature=temperature,
+                client=resolved_client,
             )
             if txt:
                 return txt
+        else:
+            logger.warning("OpenAI client unavailable; using the local report")
 
     # ===== LOCAL PATH =====
     inter_txt = _list_rules_to_text(_get("intersection", ""), meta_df, lang=lang)

--- a/InsideForest/examples/InsideForest_Caso_de_Uso.ipynb
+++ b/InsideForest/examples/InsideForest_Caso_de_Uso.ipynb
@@ -49,6 +49,7 @@
     "    \"InsideForestRegionClusterer\",\n",
     "    \"InsideForestClassRegionClusterer\",\n",
     "    \"InsideForestContinuousRegionClusterer\",\n",
+    "    \"generate_model_hypothesis\",\n",
     ")\n",
     "missing_exports = [name for name in required_exports if not hasattr(_insideforest, name)]\n",
     "if missing_exports:\n",
@@ -699,6 +700,70 @@
     "\n",
     "display(region_summary)\n",
     "display(generator_diagnostics)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "model-agnostic-hypothesis",
+   "metadata": {},
+   "source": [
+    "# Hipótesis agnósticas al tipo de modelo\n",
+    "\n",
+    "`generate_model_hypothesis` usa la misma API con clasificación tradicional, multiclase y regresión. El modo local es determinista, no requiere red y ajusta las métricas y el vocabulario a cada estimador.\n",
+    "\n",
+    "OpenAI puede mejorar la narrativa cuando existe `OPENAI_API_KEY`. Si las credenciales o la API no están disponibles, la función conserva automáticamente el informe local reproducible.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "model-agnostic-local-demo",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from InsideForest import generate_model_hypothesis\n",
+    "\n",
+    "hypothesis_models = {\n",
+    "    \"tradicional\": (traditional, \"species\"),\n",
+    "    \"multiclase\": (multiclass_model, \"wine_class\"),\n",
+    "    \"regresión\": (continuous_model, \"disease_progression\"),\n",
+    "}\n",
+    "\n",
+    "local_hypotheses = {\n",
+    "    name: generate_model_hypothesis(model, target=target, use_gpt=False)\n",
+    "    for name, (model, target) in hypothesis_models.items()\n",
+    "}\n",
+    "for name, report in local_hypotheses.items():\n",
+    "    print(f\"\\n--- {name.upper()} ---\\n{report}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "model-agnostic-openai-note",
+   "metadata": {},
+   "source": [
+    "## Demo opcional con OpenAI\n",
+    "\n",
+    "La siguiente celda está desactivada para evitar llamadas y costes accidentales. Cambia el flag solo cuando quieras usar la API; la clave se lee de `OPENAI_API_KEY` y nunca se incluye en el notebook.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "model-agnostic-openai-demo",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RUN_OPENAI_DEMO = False\n",
+    "\n",
+    "if RUN_OPENAI_DEMO:\n",
+    "    for name, (model, target) in hypothesis_models.items():\n",
+    "        report = generate_model_hypothesis(\n",
+    "            model, target=target, use_gpt=True, openai_model=\"gpt-4o-mini\"\n",
+    "        )\n",
+    "        print(f\"\\n--- OPENAI · {name.upper()} ---\\n{report}\")\n",
+    "else:\n",
+    "    print(\"Demo OpenAI desactivada; los tres informes locales ya están disponibles.\")\n"
    ]
   },
   {

--- a/tests/test_descrip.py
+++ b/tests/test_descrip.py
@@ -11,6 +11,7 @@ from InsideForest.descrip import (
     encode_features,
     _gpt_hypothesis,
     generate_hypothesis,
+    generate_model_hypothesis,
     get_frontiers,
 )
 
@@ -121,6 +122,7 @@ def test_gpt_hypothesis_handles_empty_choices(monkeypatch):
 def test_generar_hypotesis_fallback_without_gpt(monkeypatch):
     from InsideForest import descrip
     monkeypatch.setattr(descrip, "_client", None)
+    monkeypatch.setattr(descrip, "get_openai_client", lambda api_key=None: None)
     meta_df = pd.DataFrame({"rule_token": ["tok"], "identity.label_i18n.es": ["Etiqueta"]})
     exp_df = pd.DataFrame({
         "intersection": ["tok"],
@@ -168,6 +170,199 @@ def test_generar_hypotesis_handles_lowercase_columns(monkeypatch):
     result = generate_hypothesis(meta_df, exp_df, target="tok", use_gpt=False, lang="es")
     assert "Etiqueta" in result
     assert "10.00%" in result
+
+
+class FakeRegionEstimator:
+    def __init__(self, regions, classes=None):
+        self._regions = regions
+        if classes is not None:
+            self.classes_ = classes
+
+    def explain_regions(self, top_n=None):
+        result = self._regions.copy()
+        return result if top_n is None else result.head(top_n)
+
+
+def _traditional_regions():
+    return pd.DataFrame(
+        {
+            "region_id": [10, 20, 30],
+            "description": ["x <= 1", "x > 1", "x > 2"],
+            "target_distribution": [
+                {"no": 0.8, "yes": 0.2},
+                {"no": 0.3, "yes": 0.7},
+                {"no": 0.2, "yes": 0.8},
+            ],
+            "dominant_target": ["no", "yes", "yes"],
+            "dominant_probability": [0.8, 0.7, 0.8],
+            "region_score": [0.9, 0.8, 0.7],
+            "support": [30, 25, 20],
+        }
+    )
+
+
+def _multiclass_regions():
+    return pd.DataFrame(
+        {
+            "cluster_id": [1, 2, 3],
+            "description": ["a <= 1", "a > 1", "a > 2"],
+            "class_distribution": [
+                [0.8, 0.1, 0.1],
+                [0.1, 0.7, 0.2],
+                [0.1, 0.2, 0.7],
+            ],
+            "region_target_class": ["setosa", "versicolor", "virginica"],
+            "target_probability": [0.8, 0.7, 0.7],
+            "lift": [2.0, 1.8, 1.7],
+            "entropy": [0.4, 0.6, 0.6],
+            "class_margin": [0.7, 0.5, 0.5],
+            "region_score": [0.95, 0.85, 0.75],
+            "support": [20, 18, 16],
+        }
+    )
+
+
+def _regression_regions():
+    return pd.DataFrame(
+        {
+            "cluster_id": [4, 5, 6],
+            "description": ["b <= 1", "b > 1", "b > 2"],
+            "target_mean": [105.5, 155.0, 205.25],
+            "target_median": [100.0, 150.0, 200.0],
+            "target_std": [15.0, 12.0, 10.0],
+            "target_iqr": [20.0, 18.0, 15.0],
+            "mean_shift": [-45.0, 4.5, 54.75],
+            "standardized_mean_shift": [-1.0, 0.1, 1.2],
+            "dispersion_reduction": [0.1, 0.2, 0.3],
+            "region_score": [0.7, 0.8, 0.9],
+            "support": [30, 25, 20],
+        }
+    )
+
+
+def test_generate_model_hypothesis_detects_traditional_model():
+    result = generate_model_hypothesis(FakeRegionEstimator(_traditional_regions()))
+    assert "clasificación" in result
+    assert "Región 10" in result
+    assert "Región 20" in result
+    assert "Probabilidad dominante" in result
+
+
+def test_generate_model_hypothesis_detects_multiclass_string_labels():
+    estimator = FakeRegionEstimator(
+        _multiclass_regions(), classes=["setosa", "versicolor", "virginica"]
+    )
+    result = generate_model_hypothesis(estimator)
+    assert "multiclase" in result
+    assert "setosa" in result
+    assert "versicolor" in result
+    assert "Distribución" in result
+
+
+def test_generate_model_hypothesis_regression_uses_numeric_language():
+    result = generate_model_hypothesis(FakeRegionEstimator(_regression_regions()))
+    assert "regresión" in result
+    assert "Región 4" in result
+    assert "Región 6" in result
+    assert "105.500" in result
+    assert "probabilidad" not in result.lower()
+    assert "%" not in result
+
+
+def test_generate_model_hypothesis_honors_explicit_region_ids():
+    result = generate_model_hypothesis(
+        FakeRegionEstimator(_traditional_regions()), region_ids=[30, 20]
+    )
+    assert result.index("Región 30") < result.index("Región 20")
+    assert "Región 10" not in result
+
+
+def test_generate_model_hypothesis_requires_fitted_estimator():
+    class UnfittedEstimator:
+        def explain_regions(self, top_n=None):
+            raise RuntimeError("not fitted")
+
+    with pytest.raises(ValueError, match="must be fitted"):
+        generate_model_hypothesis(UnfittedEstimator())
+
+
+def test_generate_model_hypothesis_requires_two_regions():
+    one_region = _traditional_regions().head(1)
+    with pytest.raises(ValueError, match="At least two"):
+        generate_model_hypothesis(FakeRegionEstimator(one_region))
+
+
+class FakeOpenAIClient:
+    def __init__(self, content=None, error=None):
+        self.content = content
+        self.error = error
+        self.calls = []
+        self.chat = self.Chat(self)
+
+    class Chat:
+        def __init__(self, owner):
+            self.completions = FakeOpenAIClient.Completions(owner)
+
+    class Completions:
+        def __init__(self, owner):
+            self.owner = owner
+
+        def create(self, **kwargs):
+            self.owner.calls.append(kwargs)
+            if self.owner.error:
+                raise self.owner.error
+            message = type("Message", (), {"content": self.owner.content})()
+            choice = type("Choice", (), {"message": message})()
+            return type("Response", (), {"choices": [choice]})()
+
+
+def test_generate_model_hypothesis_uses_injected_openai_client():
+    client = FakeOpenAIClient("## Informe generado")
+    result = generate_model_hypothesis(
+        FakeRegionEstimator(_traditional_regions()), use_gpt=True, client=client
+    )
+    assert result == "## Informe generado"
+    assert client.calls[0]["model"] == "gpt-4o-mini"
+
+
+def test_generate_model_hypothesis_falls_back_when_openai_fails(caplog):
+    client = FakeOpenAIClient(error=RuntimeError("offline"))
+    result = generate_model_hypothesis(
+        FakeRegionEstimator(_regression_regions()), use_gpt=True, client=client
+    )
+    assert "regresión" in result
+    assert "using the local report" in caplog.text
+
+
+def test_legacy_generate_hypothesis_initializes_openai_client(monkeypatch):
+    from InsideForest import descrip
+
+    client = FakeOpenAIClient("## Hipótesis API")
+    calls = []
+
+    def fake_get_client(api_key=None):
+        calls.append(api_key)
+        return client
+
+    monkeypatch.setattr(descrip, "get_openai_client", fake_get_client)
+    meta_df = pd.DataFrame(
+        {"rule_token": ["tok"], "identity.label_i18n.es": ["Etiqueta"]}
+    )
+    exp_df = pd.DataFrame(
+        {
+            "intersection": ["tok"],
+            "only_cluster_a": [""],
+            "only_cluster_b": [""],
+            "cluster_ef_a": [0.1],
+            "cluster_ef_b": [0.2],
+            "delta_ef": [0.1],
+        }
+    )
+    result = generate_hypothesis(
+        meta_df, exp_df, target="tok", use_gpt=True, api_key="test-key"
+    )
+    assert result == "## Hipótesis API"
+    assert calls == ["test-key"]
 
 
 def test_get_frontiers_basic():

--- a/tests/test_packaged_notebook.py
+++ b/tests/test_packaged_notebook.py
@@ -30,6 +30,11 @@ def test_use_case_notebook_is_packaged_and_contains_multiclass_example():
     assert notebook["nbformat"] == 4
     assert "InsideForestClassRegionClusterer" in source
     assert "InsideForestContinuousRegionClusterer" in source
+    assert "generate_model_hypothesis" in source
+    assert "RUN_OPENAI_DEMO = False" in source
+    assert "traditional, \"species\"" in source
+    assert "multiclass_model, \"wine_class\"" in source
+    assert "continuous_model, \"disease_progression\"" in source
     assert "load_wine" in source
     assert "regions_for_class" in source
     assert "ambiguous_regions" in source
@@ -99,6 +104,7 @@ for _name in (
     "InsideForestRegionClusterer",
     "InsideForestClassRegionClusterer",
     "InsideForestContinuousRegionClusterer",
+    "generate_model_hypothesis",
 ):
     assert hasattr(_insideforest, _name)
 """


### PR DESCRIPTION
## Qué cambió

- Añade `generate_model_hypothesis` como API pública para modelos tradicionales, multiclase y de regresión.
- Detecta el tipo de tarea desde `explain_regions()`, selecciona regiones representativas y adapta métricas y narrativa.
- Centraliza el transporte OpenAI y mantiene un informe local determinista cuando faltan credenciales o la API falla.
- Corrige la inicialización del cliente en la API legacy.
- Documenta los tres flujos en el notebook canónico con la demo OpenAI desactivada por defecto.

## Por qué

La generación de hipótesis estaba acoplada a métricas binarias, por lo que podía producir textos incorrectos en regresión y no manejar correctamente perfiles multiclase. El nuevo flujo usa directamente el esquema público de regiones de cada estimador.

## Impacto

La misma llamada funciona con los tres estimadores canónicos sin generar costes por defecto. La API anterior conserva compatibilidad y ahora cae de forma segura al reporte local ante errores de OpenAI.

## Validación

- `python -m pytest tests/test_descrip.py tests/test_packaged_notebook.py -q`
- `python -m pytest tests/test_multiclass_interpreter.py tests/test_continuous_region_clusterer.py -q`
- `python -m pytest -q` → 175 passed, 1 skipped